### PR TITLE
feat: scaffold countdown plugin settings backend

### DIFF
--- a/packages/plugins/countdown/package.json
+++ b/packages/plugins/countdown/package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@emdash-cms/plugin-countdown",
+	"private": true,
+	"version": "0.0.1",
+	"description": "Countdown popup plugin for EmDash CMS",
+	"type": "module",
+	"main": "dist/index.mjs",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		},
+		"./sandbox": "./dist/sandbox-entry.mjs"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsdown src/index.ts src/sandbox-entry.ts --format esm --dts --clean",
+		"dev": "tsdown src/index.ts src/sandbox-entry.ts --format esm --dts --watch",
+		"typecheck": "tsgo --noEmit"
+	},
+	"keywords": [
+		"emdash",
+		"cms",
+		"plugin",
+		"countdown",
+		"popup"
+	],
+	"author": "Matt Kane",
+	"license": "MIT",
+	"peerDependencies": {
+		"emdash": "workspace:>=0.9.0"
+	},
+	"devDependencies": {
+		"tsdown": "catalog:",
+		"typescript": "catalog:"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/emdash-cms/emdash.git",
+		"directory": "packages/plugins/countdown"
+	}
+}

--- a/packages/plugins/countdown/src/index.ts
+++ b/packages/plugins/countdown/src/index.ts
@@ -1,0 +1,14 @@
+import type { PluginDescriptor } from "emdash";
+
+export function countdownPlugin(): PluginDescriptor {
+	return {
+		id: "countdown",
+		version: "0.0.1",
+		format: "standard",
+		entrypoint: "@emdash-cms/plugin-countdown/sandbox",
+		storage: {
+			dismissals: { indexes: ["createdAt", "sessionId"] },
+		},
+		adminPages: [{ path: "/settings", label: "Countdown Settings", icon: "clock" }],
+	};
+}

--- a/packages/plugins/countdown/src/sandbox-entry.ts
+++ b/packages/plugins/countdown/src/sandbox-entry.ts
@@ -1,0 +1,101 @@
+import { definePlugin } from "emdash";
+import type { PluginContext } from "emdash";
+
+import {
+	DEFAULT_COUNTDOWN_SETTINGS,
+	applySettingsPatch,
+	getSettingKey,
+	normalizeCountdownPatch,
+	validateCountdownSettings,
+} from "./settings.js";
+import type { CountdownSettings } from "./types.js";
+
+async function getSettings(ctx: PluginContext): Promise<CountdownSettings> {
+	const enabled = await ctx.kv.get<boolean>(getSettingKey("enabled"));
+	const targetAt = await ctx.kv.get<string>(getSettingKey("targetAt"));
+	const caption = await ctx.kv.get<string>(getSettingKey("caption"));
+	const imageUrl = await ctx.kv.get<string>(getSettingKey("imageUrl"));
+	const showFrom = await ctx.kv.get<string | null>(getSettingKey("showFrom"));
+	const showUntil = await ctx.kv.get<string | null>(getSettingKey("showUntil"));
+	const dismissOncePerSession = await ctx.kv.get<boolean>(getSettingKey("dismissOncePerSession"));
+
+	return {
+		enabled: typeof enabled === "boolean" ? enabled : DEFAULT_COUNTDOWN_SETTINGS.enabled,
+		targetAt: typeof targetAt === "string" ? targetAt : DEFAULT_COUNTDOWN_SETTINGS.targetAt,
+		caption: typeof caption === "string" ? caption : DEFAULT_COUNTDOWN_SETTINGS.caption,
+		imageUrl: typeof imageUrl === "string" ? imageUrl : DEFAULT_COUNTDOWN_SETTINGS.imageUrl,
+		showFrom:
+			typeof showFrom === "string" || showFrom === null
+				? showFrom
+				: DEFAULT_COUNTDOWN_SETTINGS.showFrom,
+		showUntil:
+			typeof showUntil === "string" || showUntil === null
+				? showUntil
+				: DEFAULT_COUNTDOWN_SETTINGS.showUntil,
+		dismissOncePerSession:
+			typeof dismissOncePerSession === "boolean"
+				? dismissOncePerSession
+				: DEFAULT_COUNTDOWN_SETTINGS.dismissOncePerSession,
+	};
+}
+
+async function saveSettings(ctx: PluginContext, settings: CountdownSettings): Promise<void> {
+	await ctx.kv.set(getSettingKey("enabled"), settings.enabled);
+	await ctx.kv.set(getSettingKey("targetAt"), settings.targetAt);
+	await ctx.kv.set(getSettingKey("caption"), settings.caption);
+	await ctx.kv.set(getSettingKey("imageUrl"), settings.imageUrl);
+	await ctx.kv.set(getSettingKey("showFrom"), settings.showFrom);
+	await ctx.kv.set(getSettingKey("showUntil"), settings.showUntil);
+	await ctx.kv.set(getSettingKey("dismissOncePerSession"), settings.dismissOncePerSession);
+}
+
+export default definePlugin({
+	hooks: {
+		"plugin:install": {
+			handler: async (_event: unknown, ctx: PluginContext) => {
+				await saveSettings(ctx, DEFAULT_COUNTDOWN_SETTINGS);
+				ctx.log.info("[countdown] defaults initialized");
+			},
+		},
+	},
+	routes: {
+		settings: {
+			handler: async (_routeCtx: unknown, ctx: PluginContext) => {
+				const settings = await getSettings(ctx);
+				const validation = validateCountdownSettings(settings);
+				if (!validation.valid) {
+					return {
+						success: false,
+						error: {
+							code: "INVALID_SETTINGS",
+							message: validation.errors.join("; "),
+						},
+					};
+				}
+
+				return { success: true, settings };
+			},
+		},
+		"settings/save": {
+			handler: async (routeCtx: { input: unknown }, ctx: PluginContext) => {
+				const current = await getSettings(ctx);
+				const patch = normalizeCountdownPatch(routeCtx.input);
+				const merged = applySettingsPatch(current, patch);
+				const validation = validateCountdownSettings(merged);
+
+				if (!validation.valid) {
+					return {
+						success: false,
+						error: {
+							code: "VALIDATION_ERROR",
+							message: validation.errors.join("; "),
+						},
+					};
+				}
+
+				await saveSettings(ctx, merged);
+				return { success: true, settings: merged };
+			},
+		},
+	},
+});

--- a/packages/plugins/countdown/src/settings.ts
+++ b/packages/plugins/countdown/src/settings.ts
@@ -1,0 +1,107 @@
+import type { CountdownSettings, CountdownSettingsPatch, ValidationResult } from "./types.js";
+
+const MAX_CAPTION_LENGTH = 280;
+const KEY_PREFIX = "settings:";
+
+export const DEFAULT_COUNTDOWN_SETTINGS: CountdownSettings = {
+	enabled: false,
+	targetAt: "",
+	caption: "",
+	imageUrl: "",
+	showFrom: null,
+	showUntil: null,
+	dismissOncePerSession: true,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isValidIsoDateTime(value: string): boolean {
+	if (!value) return false;
+	const t = Date.parse(value);
+	if (Number.isNaN(t)) return false;
+	return value.includes("T");
+}
+
+export function validateCountdownSettings(input: CountdownSettings): ValidationResult {
+	const errors: string[] = [];
+
+	if (input.caption.length > MAX_CAPTION_LENGTH) {
+		errors.push(`caption must be ${MAX_CAPTION_LENGTH} characters or less`);
+	}
+
+	if (input.enabled && !isValidIsoDateTime(input.targetAt)) {
+		errors.push("targetAt must be a valid ISO datetime when enabled is true");
+	}
+
+	if (input.targetAt && !isValidIsoDateTime(input.targetAt)) {
+		errors.push("targetAt must be a valid ISO datetime");
+	}
+
+	if (input.showFrom && !isValidIsoDateTime(input.showFrom)) {
+		errors.push("showFrom must be a valid ISO datetime or null");
+	}
+
+	if (input.showUntil && !isValidIsoDateTime(input.showUntil)) {
+		errors.push("showUntil must be a valid ISO datetime or null");
+	}
+
+	if (input.showFrom && input.showUntil) {
+		const fromAt = Date.parse(input.showFrom);
+		const untilAt = Date.parse(input.showUntil);
+		if (fromAt > untilAt) {
+			errors.push("showFrom must be before or equal to showUntil");
+		}
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+export function normalizeCountdownPatch(input: unknown): CountdownSettingsPatch {
+	if (!isRecord(input)) return {};
+
+	const patch: CountdownSettingsPatch = {};
+
+	if ("enabled" in input) patch.enabled = input.enabled;
+	if ("targetAt" in input) patch.targetAt = input.targetAt;
+	if ("caption" in input) patch.caption = input.caption;
+	if ("imageUrl" in input) patch.imageUrl = input.imageUrl;
+	if ("showFrom" in input) patch.showFrom = input.showFrom;
+	if ("showUntil" in input) patch.showUntil = input.showUntil;
+	if ("dismissOncePerSession" in input) patch.dismissOncePerSession = input.dismissOncePerSession;
+
+	return patch;
+}
+
+export function applySettingsPatch(
+	base: CountdownSettings,
+	patch: CountdownSettingsPatch,
+): CountdownSettings {
+	return {
+		enabled: typeof patch.enabled === "boolean" ? patch.enabled : base.enabled,
+		targetAt: typeof patch.targetAt === "string" ? patch.targetAt.trim() : base.targetAt,
+		caption: typeof patch.caption === "string" ? patch.caption.trim() : base.caption,
+		imageUrl: typeof patch.imageUrl === "string" ? patch.imageUrl.trim() : base.imageUrl,
+		showFrom:
+			patch.showFrom === null
+				? null
+				: typeof patch.showFrom === "string"
+					? patch.showFrom.trim()
+					: base.showFrom,
+		showUntil:
+			patch.showUntil === null
+				? null
+				: typeof patch.showUntil === "string"
+					? patch.showUntil.trim()
+					: base.showUntil,
+		dismissOncePerSession:
+			typeof patch.dismissOncePerSession === "boolean"
+				? patch.dismissOncePerSession
+				: base.dismissOncePerSession,
+	};
+}
+
+export function getSettingKey(field: keyof CountdownSettings): string {
+	return `${KEY_PREFIX}${field}`;
+}

--- a/packages/plugins/countdown/src/types.ts
+++ b/packages/plugins/countdown/src/types.ts
@@ -1,0 +1,24 @@
+export interface CountdownSettings {
+	enabled: boolean;
+	targetAt: string;
+	caption: string;
+	imageUrl: string;
+	showFrom: string | null;
+	showUntil: string | null;
+	dismissOncePerSession: boolean;
+}
+
+export interface CountdownSettingsPatch {
+	enabled?: unknown;
+	targetAt?: unknown;
+	caption?: unknown;
+	imageUrl?: unknown;
+	showFrom?: unknown;
+	showUntil?: unknown;
+	dismissOncePerSession?: unknown;
+}
+
+export interface ValidationResult {
+	valid: boolean;
+	errors: string[];
+}

--- a/packages/plugins/countdown/tests/settings.test.ts
+++ b/packages/plugins/countdown/tests/settings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_COUNTDOWN_SETTINGS,
+	applySettingsPatch,
+	normalizeCountdownPatch,
+	validateCountdownSettings,
+} from "../src/settings.js";
+
+describe("countdown settings", () => {
+	it("accepts default settings", () => {
+		const result = validateCountdownSettings(DEFAULT_COUNTDOWN_SETTINGS);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("rejects enabled settings without a valid target datetime", () => {
+		const result = validateCountdownSettings({
+			...DEFAULT_COUNTDOWN_SETTINGS,
+			enabled: true,
+			targetAt: "",
+		});
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("targetAt must be a valid ISO datetime when enabled is true");
+	});
+
+	it("rejects invalid visibility window order", () => {
+		const result = validateCountdownSettings({
+			...DEFAULT_COUNTDOWN_SETTINGS,
+			showFrom: "2027-01-02T10:00:00.000Z",
+			showUntil: "2027-01-02T09:00:00.000Z",
+		});
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("showFrom must be before or equal to showUntil");
+	});
+
+	it("normalizes and applies patch values", () => {
+		const patch = normalizeCountdownPatch({
+			enabled: true,
+			targetAt: " 2027-06-01T00:00:00.000Z ",
+			caption: " School anniversary ",
+			imageUrl: " https://cdn.example.com/banner.png ",
+			showFrom: null,
+			dismissOncePerSession: false,
+		});
+
+		const settings = applySettingsPatch(DEFAULT_COUNTDOWN_SETTINGS, patch);
+		expect(settings.enabled).toBe(true);
+		expect(settings.targetAt).toBe("2027-06-01T00:00:00.000Z");
+		expect(settings.caption).toBe("School anniversary");
+		expect(settings.imageUrl).toBe("https://cdn.example.com/banner.png");
+		expect(settings.showFrom).toBeNull();
+		expect(settings.dismissOncePerSession).toBe(false);
+	});
+});

--- a/packages/plugins/countdown/tsconfig.json
+++ b/packages/plugins/countdown/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What does this PR do?

Implements the first atomic slice of the countdown plugin plan: package scaffold plus validated backend settings contract and routes. This establishes the plugin foundation for admin UI and public renderer work in follow-up issues.

Closes #84

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `pnpm --filter @emdash-cms/plugin-countdown typecheck` passed
- `pnpm --filter @emdash-cms/plugin-countdown exec vitest run` passed