### PR TITLE
fix: correct public kelulusan telemetry event semantics

### DIFF
--- a/demos/simple/src/pages/kelulusan.astro
+++ b/demos/simple/src/pages/kelulusan.astro
@@ -5,7 +5,7 @@ import Base from "../layouts/Base.astro";
 <Base title="Kelulusan" description="Akses hasil kelulusan dengan NISN">
 	<section class="kelulusan-wrap">
 		<h1>Kelulusan</h1>
-		<p class="intro">Masukkan NISN untuk melihat data kelulusan dan dokumen PDF.</p>
+		<p class="intro">Masukkan NISN untuk memulai sesi dan lanjut ke halaman hasil kelulusan.</p>
 
 		<form id="nisn-form" class="nisn-form">
 			<label for="nisn-input">NISN</label>
@@ -27,44 +27,14 @@ import Base from "../layouts/Base.astro";
 
 		<p id="status" class="status" role="status" aria-live="polite"></p>
 
-		<section id="result" class="result hidden" aria-live="polite">
-			<h2>Data Siswa</h2>
-			<dl>
-				<div><dt>NISN</dt><dd id="out-nisn">-</dd></div>
-				<div><dt>Nama</dt><dd id="out-name">-</dd></div>
-				<div><dt>File PDF</dt><dd id="out-file">-</dd></div>
-			</dl>
-			<div class="actions">
-				<button id="open-pdf" type="button">Buka PDF</button>
-				<a id="download-pdf" class="download" href="#" target="_blank" rel="noopener">Unduh PDF</a>
-			</div>
-		</section>
 	</section>
-
-	<dialog id="pdf-dialog" class="pdf-dialog">
-		<div class="pdf-head">
-			<strong id="dialog-title">Dokumen Kelulusan</strong>
-			<button id="close-dialog" type="button" aria-label="Tutup">Tutup</button>
-		</div>
-		<iframe id="pdf-frame" title="PDF Kelulusan"></iframe>
-	</dialog>
 
 	<script is:inline>
 		const API_BASE = "/_emdash/api/plugins/kelulusan";
-		const state = { nisn: "", accessToken: "", pdfUrl: "", pdfFilename: "" };
-
 		const form = document.getElementById("nisn-form");
 		const statusEl = document.getElementById("status");
-		const resultEl = document.getElementById("result");
-		const outNisn = document.getElementById("out-nisn");
-		const outName = document.getElementById("out-name");
-		const outFile = document.getElementById("out-file");
-		const openPdfBtn = document.getElementById("open-pdf");
-		const downloadPdf = document.getElementById("download-pdf");
-		const dialog = document.getElementById("pdf-dialog");
-		const closeDialog = document.getElementById("close-dialog");
-		const frame = document.getElementById("pdf-frame");
-		const title = document.getElementById("dialog-title");
+
+		const SESSION_KEY = "kelulusan:gate-session";
 
 		async function apiPost(path, body) {
 			const res = await fetch(`${API_BASE}/${path}`, {
@@ -85,17 +55,12 @@ import Base from "../layouts/Base.astro";
 			statusEl.classList.toggle("error", isError);
 		}
 
-		function showResult(data) {
-			outNisn.textContent = data.nisn;
-			outName.textContent = data.name;
-			outFile.textContent = data.pdfFilename;
-			resultEl.classList.remove("hidden");
-		}
+		const reason = new URLSearchParams(window.location.search).get("reason");
+		if (reason) showMessage(reason, true);
 
 		form.addEventListener("submit", async (event) => {
 			event.preventDefault();
 			showMessage("Memverifikasi NISN...");
-			resultEl.classList.add("hidden");
 
 			const nisn = String(new FormData(form).get("nisn") || "").trim();
 			if (!nisn) {
@@ -105,71 +70,19 @@ import Base from "../layouts/Base.astro";
 
 			try {
 				const session = await apiPost("gate/session/start", { nisn });
-				state.nisn = session.nisn;
-				state.accessToken = session.accessToken;
-				showResult(session);
-				showMessage("NISN valid. Anda dapat membuka dokumen PDF.");
-
-				const opened = await apiPost("documents/access/public", {
-					nisn: state.nisn,
-					accessToken: state.accessToken,
-					eventType: "opened",
-				});
-				state.pdfUrl = opened.pdfUrl;
-				state.pdfFilename = opened.pdfFilename;
-				downloadPdf.href = opened.pdfUrl;
-				downloadPdf.download = opened.pdfFilename;
+				sessionStorage.setItem(
+					SESSION_KEY,
+					JSON.stringify({
+						nisn: session.nisn,
+						accessToken: session.accessToken,
+						expiresAt: session.expiresAt,
+					}),
+				);
+				showMessage("NISN valid. Mengalihkan ke halaman hasil...");
+				window.location.assign("/kelulusan/hasil");
 			} catch (error) {
 				showMessage(error instanceof Error ? error.message : "NISN tidak valid", true);
 			}
-		});
-
-		openPdfBtn.addEventListener("click", async () => {
-			if (!state.nisn || !state.accessToken) {
-				showMessage("Masukkan NISN terlebih dahulu.", true);
-				return;
-			}
-
-			try {
-				const opened = await apiPost("documents/access/public", {
-					nisn: state.nisn,
-					accessToken: state.accessToken,
-					eventType: "opened",
-				});
-				state.pdfUrl = opened.pdfUrl;
-				state.pdfFilename = opened.pdfFilename;
-				frame.src = `${opened.pdfUrl}#toolbar=1&navpanes=0`;
-				title.textContent = opened.pdfFilename;
-				dialog.showModal();
-			} catch (error) {
-				showMessage(error instanceof Error ? error.message : "Gagal membuka PDF", true);
-			}
-		});
-
-		downloadPdf.addEventListener("click", async (event) => {
-			if (!state.nisn || !state.accessToken) {
-				event.preventDefault();
-				showMessage("Masukkan NISN terlebih dahulu.", true);
-				return;
-			}
-
-			try {
-				const downloaded = await apiPost("documents/access/public", {
-					nisn: state.nisn,
-					accessToken: state.accessToken,
-					eventType: "downloaded",
-				});
-				downloadPdf.href = downloaded.pdfUrl;
-				downloadPdf.download = downloaded.pdfFilename;
-			} catch (error) {
-				event.preventDefault();
-				showMessage(error instanceof Error ? error.message : "Gagal mengunduh PDF", true);
-			}
-		});
-
-		closeDialog.addEventListener("click", () => {
-			dialog.close();
-			frame.src = "";
 		});
 	</script>
 </Base>
@@ -183,20 +96,7 @@ import Base from "../layouts/Base.astro";
 	.row button, .actions button, .actions .download { padding: 0.75rem 1rem; border-radius: var(--radius); border: 1px solid var(--color-border); background: var(--color-text); color: var(--color-bg); text-decoration: none; cursor: pointer; }
 	.status { min-height: 1.5rem; margin-top: var(--spacing-4); }
 	.status.error { color: #b91c1c; }
-	.result { margin-top: var(--spacing-6); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-5); }
-	.result.hidden { display: none; }
-	.result dl { display: grid; gap: var(--spacing-3); }
-	.result dt { font-size: 0.85rem; color: var(--color-text-secondary); }
-	.result dd { margin: 0; font-weight: 600; }
-	.actions { margin-top: var(--spacing-4); display: flex; gap: var(--spacing-3); }
-	.pdf-dialog { width: min(92vw, 980px); border: 0; padding: 0; border-radius: var(--radius-lg); overflow: hidden; }
-	.pdf-dialog::backdrop { background: rgba(0, 0, 0, 0.58); }
-	.pdf-head { display: flex; justify-content: space-between; align-items: center; padding: 0.85rem 1rem; border-bottom: 1px solid var(--color-border); }
-	.pdf-head button { border: 1px solid var(--color-border); background: transparent; border-radius: var(--radius); padding: 0.4rem 0.75rem; cursor: pointer; }
-	#pdf-frame { width: 100%; height: min(80vh, 760px); border: 0; }
-
 	@media (max-width: 720px) {
 		.row { flex-direction: column; }
-		.actions { flex-direction: column; }
 	}
 </style>

--- a/demos/simple/src/pages/kelulusan/hasil.astro
+++ b/demos/simple/src/pages/kelulusan/hasil.astro
@@ -1,0 +1,191 @@
+---
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Hasil Kelulusan" description="Data kelulusan siswa">
+	<section class="kelulusan-wrap">
+		<h1>Hasil Kelulusan</h1>
+		<p class="intro">Halaman ini hanya dapat diakses dengan sesi valid dari halaman NISN.</p>
+
+		<p id="status" class="status" role="status" aria-live="polite"></p>
+
+		<section id="result" class="result hidden" aria-live="polite">
+			<h2>Data Siswa</h2>
+			<dl>
+				<div><dt>NISN</dt><dd id="out-nisn">-</dd></div>
+				<div><dt>Nama</dt><dd id="out-name">-</dd></div>
+				<div><dt>File PDF</dt><dd id="out-file">-</dd></div>
+			</dl>
+			<div class="actions">
+				<button id="open-pdf" type="button">Buka PDF</button>
+				<a id="download-pdf" class="download" href="#" target="_blank" rel="noopener">Unduh PDF</a>
+			</div>
+		</section>
+	</section>
+
+	<dialog id="pdf-dialog" class="pdf-dialog">
+		<div class="pdf-head">
+			<strong id="dialog-title">Dokumen Kelulusan</strong>
+			<button id="close-dialog" type="button" aria-label="Tutup">Tutup</button>
+		</div>
+		<iframe id="pdf-frame" title="PDF Kelulusan"></iframe>
+	</dialog>
+
+	<script is:inline>
+		const API_BASE = "/_emdash/api/plugins/kelulusan";
+		const SESSION_KEY = "kelulusan:gate-session";
+		const state = { nisn: "", accessToken: "", pdfUrl: "", pdfFilename: "" };
+
+		const statusEl = document.getElementById("status");
+		const resultEl = document.getElementById("result");
+		const outNisn = document.getElementById("out-nisn");
+		const outName = document.getElementById("out-name");
+		const outFile = document.getElementById("out-file");
+		const openPdfBtn = document.getElementById("open-pdf");
+		const downloadPdf = document.getElementById("download-pdf");
+		const dialog = document.getElementById("pdf-dialog");
+		const closeDialog = document.getElementById("close-dialog");
+		const frame = document.getElementById("pdf-frame");
+		const title = document.getElementById("dialog-title");
+
+		async function apiPost(path, body) {
+			const res = await fetch(`${API_BASE}/${path}`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			const payload = await res.json().catch(() => ({}));
+			if (!res.ok || !payload.success) {
+				const message = payload?.error?.message || "Permintaan gagal";
+				throw new Error(message);
+			}
+			return payload.data;
+		}
+
+		function showMessage(message, isError = false) {
+			statusEl.textContent = message;
+			statusEl.classList.toggle("error", isError);
+		}
+
+		function showResult(data) {
+			outNisn.textContent = data.nisn;
+			outName.textContent = data.name;
+			outFile.textContent = data.pdfFilename;
+			resultEl.classList.remove("hidden");
+		}
+
+		function redirectToGate(message) {
+			sessionStorage.removeItem(SESSION_KEY);
+			const target = `/kelulusan?reason=${encodeURIComponent(message)}`;
+			window.location.replace(target);
+		}
+
+		async function init() {
+			const raw = sessionStorage.getItem(SESSION_KEY);
+			if (!raw) {
+				redirectToGate("Sesi tidak ditemukan. Silakan verifikasi NISN kembali.");
+				return;
+			}
+
+			let session;
+			try {
+				session = JSON.parse(raw);
+			} catch {
+				redirectToGate("Sesi tidak valid. Silakan verifikasi NISN kembali.");
+				return;
+			}
+
+			state.nisn = typeof session.nisn === "string" ? session.nisn : "";
+			state.accessToken = typeof session.accessToken === "string" ? session.accessToken : "";
+			if (!state.nisn || !state.accessToken) {
+				redirectToGate("Sesi tidak lengkap. Silakan verifikasi NISN kembali.");
+				return;
+			}
+
+			showMessage("Memverifikasi sesi...");
+			try {
+				const summary = await apiPost("gate/session/resolve", {
+					nisn: state.nisn,
+					accessToken: state.accessToken,
+				});
+				showResult(summary);
+				showMessage("Sesi valid. Anda dapat membuka dokumen PDF.");
+			} catch (error) {
+				redirectToGate(
+					error instanceof Error
+						? error.message
+						: "Sesi kedaluwarsa. Silakan verifikasi NISN kembali.",
+				);
+			}
+		}
+
+		openPdfBtn.addEventListener("click", async () => {
+			if (!state.nisn || !state.accessToken) return;
+			try {
+				const opened = await apiPost("documents/access/public", {
+					nisn: state.nisn,
+					accessToken: state.accessToken,
+					eventType: "opened",
+				});
+				state.pdfUrl = opened.pdfUrl;
+				state.pdfFilename = opened.pdfFilename;
+				downloadPdf.href = opened.pdfUrl;
+				downloadPdf.download = opened.pdfFilename;
+				frame.src = `${opened.pdfUrl}#toolbar=1&navpanes=0`;
+				title.textContent = opened.pdfFilename;
+				dialog.showModal();
+			} catch (error) {
+				showMessage(error instanceof Error ? error.message : "Gagal membuka PDF", true);
+			}
+		});
+
+		downloadPdf.addEventListener("click", async (event) => {
+			if (!state.nisn || !state.accessToken) {
+				event.preventDefault();
+				return;
+			}
+			try {
+				const downloaded = await apiPost("documents/access/public", {
+					nisn: state.nisn,
+					accessToken: state.accessToken,
+					eventType: "downloaded",
+				});
+				downloadPdf.href = downloaded.pdfUrl;
+				downloadPdf.download = downloaded.pdfFilename;
+			} catch (error) {
+				event.preventDefault();
+				showMessage(error instanceof Error ? error.message : "Gagal mengunduh PDF", true);
+			}
+		});
+
+		closeDialog.addEventListener("click", () => {
+			dialog.close();
+			frame.src = "";
+		});
+
+		void init();
+	</script>
+</Base>
+
+<style>
+	.kelulusan-wrap { max-width: 760px; margin: 0 auto; padding: var(--spacing-12) var(--spacing-6); }
+	.intro { color: var(--color-text-secondary); margin-bottom: var(--spacing-6); }
+	.status { min-height: 1.5rem; margin-top: var(--spacing-4); }
+	.status.error { color: #b91c1c; }
+	.result { margin-top: var(--spacing-6); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-5); }
+	.result.hidden { display: none; }
+	.result dl { display: grid; gap: var(--spacing-3); }
+	.result dt { font-size: 0.85rem; color: var(--color-text-secondary); }
+	.result dd { margin: 0; font-weight: 600; }
+	.actions { margin-top: var(--spacing-4); display: flex; gap: var(--spacing-3); }
+	.actions button, .actions .download { padding: 0.75rem 1rem; border-radius: var(--radius); border: 1px solid var(--color-border); background: var(--color-text); color: var(--color-bg); text-decoration: none; cursor: pointer; }
+	.pdf-dialog { width: min(92vw, 980px); border: 0; padding: 0; border-radius: var(--radius-lg); overflow: hidden; }
+	.pdf-dialog::backdrop { background: rgba(0, 0, 0, 0.58); }
+	.pdf-head { display: flex; justify-content: space-between; align-items: center; padding: 0.85rem 1rem; border-bottom: 1px solid var(--color-border); }
+	.pdf-head button { border: 1px solid var(--color-border); background: transparent; border-radius: var(--radius); padding: 0.4rem 0.75rem; cursor: pointer; }
+	#pdf-frame { width: 100%; height: min(80vh, 760px); border: 0; }
+
+	@media (max-width: 720px) {
+		.actions { flex-direction: column; }
+	}
+</style>

--- a/e2e/fixture/src/pages/kelulusan.astro
+++ b/e2e/fixture/src/pages/kelulusan.astro
@@ -11,31 +11,11 @@
 		</form>
 		<p id="status" role="status"></p>
 
-		<section id="result" hidden>
-			<p id="student-nisn"></p>
-			<p id="student-name"></p>
-			<p id="student-file"></p>
-			<button id="open-pdf" type="button">Buka PDF</button>
-			<a id="download-pdf" href="#" target="_blank" rel="noopener">Unduh PDF</a>
-		</section>
-
-		<dialog id="pdf-dialog">
-			<button id="close-dialog" type="button">Tutup</button>
-			<iframe id="pdf-frame" title="PDF Kelulusan"></iframe>
-		</dialog>
-
 		<script is:inline>
 			const API_BASE = "/_emdash/api/plugins/kelulusan";
-			const state = { nisn: "", token: "", pdfUrl: "" };
-
+			const SESSION_KEY = "kelulusan:gate-session";
 			const form = document.getElementById("nisn-form");
 			const statusEl = document.getElementById("status");
-			const resultEl = document.getElementById("result");
-			const openBtn = document.getElementById("open-pdf");
-			const downloadLink = document.getElementById("download-pdf");
-			const dialog = document.getElementById("pdf-dialog");
-			const closeBtn = document.getElementById("close-dialog");
-			const frame = document.getElementById("pdf-frame");
 
 			async function post(path, body) {
 				const response = await fetch(`${API_BASE}/${path}`, {
@@ -66,51 +46,18 @@
 
 				try {
 					const session = await post("gate/session/start", { nisn });
-					state.nisn = session.nisn;
-					state.token = session.accessToken;
-					document.getElementById("student-nisn").textContent = `NISN: ${session.nisn}`;
-					document.getElementById("student-name").textContent = `Nama: ${session.name}`;
-					document.getElementById("student-file").textContent = `File: ${session.pdfFilename}`;
-					resultEl.hidden = false;
-					statusEl.textContent = "NISN valid";
-
-					const opened = await post("documents/access/public", {
-						nisn: session.nisn,
-						accessToken: session.accessToken,
-						eventType: "opened",
-					});
-					state.pdfUrl = opened.pdfUrl;
-					downloadLink.href = opened.pdfUrl;
-					downloadLink.download = opened.pdfFilename;
+					sessionStorage.setItem(
+						SESSION_KEY,
+						JSON.stringify({
+							nisn: session.nisn,
+							accessToken: session.accessToken,
+							expiresAt: session.expiresAt,
+						}),
+					);
+					window.location.assign("/kelulusan/hasil");
 				} catch (error) {
 					statusEl.textContent = error instanceof Error ? error.message : "NISN invalid";
 				}
-			});
-
-			openBtn.addEventListener("click", async () => {
-				if (!state.nisn || !state.token) return;
-				const opened = await post("documents/access/public", {
-					nisn: state.nisn,
-					accessToken: state.token,
-					eventType: "opened",
-				});
-				frame.src = `${opened.pdfUrl}#toolbar=1&navpanes=0`;
-				dialog.showModal();
-			});
-
-			downloadLink.addEventListener("click", async () => {
-				if (!state.nisn || !state.token) return;
-				const downloaded = await post("documents/access/public", {
-					nisn: state.nisn,
-					accessToken: state.token,
-					eventType: "downloaded",
-				});
-				downloadLink.href = downloaded.pdfUrl;
-			});
-
-			closeBtn.addEventListener("click", () => {
-				dialog.close();
-				frame.src = "";
 			});
 		</script>
 	</body>

--- a/e2e/fixture/src/pages/kelulusan/hasil.astro
+++ b/e2e/fixture/src/pages/kelulusan/hasil.astro
@@ -1,0 +1,124 @@
+---
+---
+
+<html>
+	<body>
+		<h1>Hasil Kelulusan</h1>
+		<p id="status" role="status"></p>
+
+		<section id="result" hidden>
+			<p id="student-nisn"></p>
+			<p id="student-name"></p>
+			<p id="student-file"></p>
+			<button id="open-pdf" type="button">Buka PDF</button>
+			<a id="download-pdf" href="#" target="_blank" rel="noopener">Unduh PDF</a>
+		</section>
+
+		<dialog id="pdf-dialog">
+			<button id="close-dialog" type="button">Tutup</button>
+			<iframe id="pdf-frame" title="PDF Kelulusan"></iframe>
+		</dialog>
+
+		<script is:inline>
+			const API_BASE = "/_emdash/api/plugins/kelulusan";
+			const SESSION_KEY = "kelulusan:gate-session";
+			const state = { nisn: "", token: "", pdfUrl: "" };
+
+			const statusEl = document.getElementById("status");
+			const resultEl = document.getElementById("result");
+			const openBtn = document.getElementById("open-pdf");
+			const downloadLink = document.getElementById("download-pdf");
+			const dialog = document.getElementById("pdf-dialog");
+			const closeBtn = document.getElementById("close-dialog");
+			const frame = document.getElementById("pdf-frame");
+
+			async function post(path, body) {
+				const response = await fetch(`${API_BASE}/${path}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+				});
+				const payload = await response.json().catch(() => ({}));
+				if (!response.ok) {
+					throw new Error(payload?.error?.message || "Request failed");
+				}
+				if (payload && typeof payload === "object" && "success" in payload) {
+					if (!payload.success) {
+						throw new Error(payload?.error?.message || "Request failed");
+					}
+					return payload.data;
+				}
+				if (payload && typeof payload === "object" && "data" in payload) {
+					return payload.data;
+				}
+				return payload;
+			}
+
+			function goToGate() {
+				sessionStorage.removeItem(SESSION_KEY);
+				window.location.replace("/kelulusan");
+			}
+
+			async function init() {
+				const raw = sessionStorage.getItem(SESSION_KEY);
+				if (!raw) {
+					goToGate();
+					return;
+				}
+
+				let session;
+				try {
+					session = JSON.parse(raw);
+				} catch {
+					goToGate();
+					return;
+				}
+
+				state.nisn = typeof session.nisn === "string" ? session.nisn : "";
+				state.token = typeof session.accessToken === "string" ? session.accessToken : "";
+				if (!state.nisn || !state.token) {
+					goToGate();
+					return;
+				}
+
+				const summary = await post("gate/session/resolve", {
+					nisn: state.nisn,
+					accessToken: state.token,
+				});
+				document.getElementById("student-nisn").textContent = `NISN: ${summary.nisn}`;
+				document.getElementById("student-name").textContent = `Nama: ${summary.name}`;
+				document.getElementById("student-file").textContent = `File: ${summary.pdfFilename}`;
+				resultEl.hidden = false;
+				statusEl.textContent = "NISN valid";
+			}
+
+			openBtn.addEventListener("click", async () => {
+				if (!state.nisn || !state.token) return;
+				const opened = await post("documents/access/public", {
+					nisn: state.nisn,
+					accessToken: state.token,
+					eventType: "opened",
+				});
+				frame.src = `${opened.pdfUrl}#toolbar=1&navpanes=0`;
+				dialog.showModal();
+			});
+
+			downloadLink.addEventListener("click", async () => {
+				if (!state.nisn || !state.token) return;
+				const downloaded = await post("documents/access/public", {
+					nisn: state.nisn,
+					accessToken: state.token,
+					eventType: "downloaded",
+				});
+				downloadLink.href = downloaded.pdfUrl;
+			});
+
+			closeBtn.addEventListener("click", () => {
+				dialog.close();
+				frame.src = "";
+			});
+
+			void init().catch(() => goToGate());
+		</script>
+	</body>
+</html>

--- a/e2e/tests/kelulusan.spec.ts
+++ b/e2e/tests/kelulusan.spec.ts
@@ -41,6 +41,7 @@ test.describe("Kelulusan flows", () => {
 		await page.goto("/kelulusan");
 		await page.fill("#nisn", "1234567890");
 		await page.click("button[type='submit']");
+		await expect(page).toHaveURL(/\/kelulusan\/hasil$/);
 
 		await expect(page.locator("#result")).toBeVisible();
 		await expect(page.locator("#student-name")).toContainText("Siswa Uji");
@@ -48,6 +49,11 @@ test.describe("Kelulusan flows", () => {
 		await page.click("#open-pdf");
 		await expect(page.locator("#pdf-dialog")).toHaveAttribute("open", "");
 		await expect(page.locator("#pdf-frame")).toHaveAttribute("src", /\/media\//);
+	});
+
+	test("result page redirects to gate without valid session", async ({ page }) => {
+		await page.goto("/kelulusan/hasil");
+		await expect(page).toHaveURL(/\/kelulusan$/);
 	});
 
 	test("admin list shows row and updates telemetry after actions", async ({ admin, page, serverInfo }) => {

--- a/packages/plugins/kelulusan/README.md
+++ b/packages/plugins/kelulusan/README.md
@@ -30,6 +30,7 @@ Scaffold package for the `kelulusan` plugin with storage and route surface for N
 - `students/upsert` - admin route for creating/updating student records
 - `students/get-by-nisn` - public student lookup by NISN
 - `gate/session/start` - public NISN gate session issuer with short-lived access token
+- `gate/session/resolve` - validates active gate session and returns student summary for result page
 - `documents/access/public` - NISN + gate token PDF access with telemetry event
 - `documents/access/admin` - authenticated admin PDF access with telemetry event
 

--- a/packages/plugins/kelulusan/README.md
+++ b/packages/plugins/kelulusan/README.md
@@ -37,3 +37,5 @@ Scaffold package for the `kelulusan` plugin with storage and route surface for N
 ## Notes
 
 This package intentionally provides only the issue #69 scaffold. Business logic, access control, telemetry persistence, and viewers are implemented in follow-up issues.
+
+Public telemetry events are deduplicated for a short window to reduce accidental double-counting from rapid repeated clicks.

--- a/packages/plugins/kelulusan/src/sandbox-entry.ts
+++ b/packages/plugins/kelulusan/src/sandbox-entry.ts
@@ -14,6 +14,11 @@ const gateSessionStartSchema = z.object({
 	nisn: z.string().trim().min(6).max(32),
 });
 
+const gateSessionResolveSchema = z.object({
+	nisn: z.string().trim().min(6).max(32),
+	accessToken: z.string().trim().min(8),
+});
+
 const documentAccessSchema = z.object({
 	nisn: z.string().trim().min(6).max(32),
 	accessToken: z.string().trim().min(8).optional(),
@@ -324,6 +329,28 @@ export default definePlugin({
 					name: student.name,
 					pdfFilename: student.pdfFilename,
 					...session,
+				};
+			},
+		},
+		"gate/session/resolve": {
+			public: true,
+			input: gateSessionResolveSchema,
+			handler: async (routeCtx: any, pluginCtx: any) => {
+				const ctx = { ...pluginCtx, ...routeCtx };
+				const student = await findStudentByNisn(ctx, ctx.input.nisn);
+				if (!student) {
+					throw PluginRouteError.notFound("Student record not found");
+				}
+
+				const authorized = await isValidGateSession(ctx, student.nisn, ctx.input.accessToken);
+				if (!authorized) {
+					throw PluginRouteError.forbidden("Invalid or expired access token");
+				}
+
+				return {
+					nisn: student.nisn,
+					name: student.name,
+					pdfFilename: student.pdfFilename,
 				};
 			},
 		},

--- a/packages/plugins/kelulusan/src/sandbox-entry.ts
+++ b/packages/plugins/kelulusan/src/sandbox-entry.ts
@@ -66,6 +66,7 @@ type RateLimitState = {
 const RATE_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LOCK_MS = 15 * 60 * 1000;
 const RATE_MAX_ATTEMPTS = 20;
+const PUBLIC_EVENT_DEDUPE_MS = 5 * 1000;
 
 function nowIso() {
 	return new Date().toISOString();
@@ -133,6 +134,25 @@ async function recordDocumentEvent(ctx: any, student: StudentRecord, eventType: 
 		actorType,
 		createdAt: nowIso(),
 	});
+}
+
+async function shouldRecordPublicEvent(
+	ctx: any,
+	studentNisn: string,
+	eventType: "opened" | "downloaded",
+	accessToken: string,
+): Promise<boolean> {
+	const key = `event-dedupe:${studentNisn}:${eventType}:${accessToken}`;
+	const last = (await ctx.kv.get(key)) as string | null;
+	const now = Date.now();
+	if (last) {
+		const age = now - toTime(last);
+		if (age >= 0 && age < PUBLIC_EVENT_DEDUPE_MS) {
+			return false;
+		}
+	}
+	await ctx.kv.set(key, new Date(now).toISOString());
+	return true;
 }
 
 async function buildTelemetrySummary(ctx: any, studentIds: string[]) {
@@ -378,7 +398,15 @@ export default definePlugin({
 					throw PluginRouteError.notFound("Student document not found");
 				}
 
-				await recordDocumentEvent(ctx, student, ctx.input.eventType, "public");
+				const shouldRecord = await shouldRecordPublicEvent(
+					ctx,
+					student.nisn,
+					ctx.input.eventType,
+					ctx.input.accessToken,
+				);
+				if (shouldRecord) {
+					await recordDocumentEvent(ctx, student, ctx.input.eventType, "public");
+				}
 
 				return {
 					nisn: student.nisn,

--- a/packages/plugins/kelulusan/tests/sandbox-entry.test.ts
+++ b/packages/plugins/kelulusan/tests/sandbox-entry.test.ts
@@ -208,4 +208,48 @@ describe("kelulusan plugin routes", () => {
 		expect(listed.items[0].lastOpenedAt).toBeTruthy();
 		expect(listed.items[0].lastDownloadedAt).toBeTruthy();
 	});
+
+	it("deduplicates rapid repeated public opened events", async () => {
+		const startRoute = (plugin as any).routes["gate/session/start"];
+		const accessPublicRoute = (plugin as any).routes["documents/access/public"];
+		const listRoute = (plugin as any).routes["students/list"];
+
+		const { ctx, students } = makeCtx({ nisn: "1122334455" }, { ip: "10.1.2.3" });
+
+		await students.put("stu-3", {
+			nisn: "1122334455",
+			name: "Dina",
+			pdfMediaId: "pdf-3",
+			pdfFilename: "dina.pdf",
+			createdAt: "2026-02-01T00:00:00.000Z",
+		});
+
+		const start = await startRoute.handler({
+			...ctx,
+			input: startRoute.input.parse({ nisn: "1122334455" }),
+		});
+
+		const payload = {
+			nisn: "1122334455",
+			accessToken: start.accessToken,
+			eventType: "opened",
+		};
+
+		await accessPublicRoute.handler({
+			...ctx,
+			input: accessPublicRoute.input.parse(payload),
+		});
+		await accessPublicRoute.handler({
+			...ctx,
+			input: accessPublicRoute.input.parse(payload),
+		});
+
+		const listed = await listRoute.handler({
+			...ctx,
+			input: listRoute.input.parse({ limit: 10 }),
+		});
+
+		expect(listed.items).toHaveLength(1);
+		expect(listed.items[0].openedCount).toBe(1);
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Implements issue #95 by improving public PDF interaction telemetry correctness in the kelulusan plugin.

Closes #95
Depends on #98

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `pnpm --filter @emdash-cms/plugin-kelulusan typecheck` passed
- `pnpm --filter @emdash-cms/plugin-kelulusan test` passed
- `pnpm exec playwright test e2e/tests/kelulusan.spec.ts --project=chromium` passed