### PR TITLE
fix: remediate js/command-line-injection in log safety script

### DIFF
--- a/scripts/log-safety-check.mjs
+++ b/scripts/log-safety-check.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -8,6 +8,7 @@ const SENSITIVE_PATTERN = /\b(authorization|cookie|set-cookie|token|password|sec
 const SUPPRESS_MARKER = "log-safety: allow";
 const CONSOLE_LOG_PATTERN = /console\.(debug|info|log|warn|error)\(/;
 const STRUCTURED_LOG_PATTERN = /logEvent\(/;
+const SAFE_REF_PATTERN = /^[A-Za-z0-9_./:-]+$/;
 
 const SCAN_DIRS = ["packages/core/src", "packages/admin/src", "demos/simple/src"];
 const SCAN_EXTS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs", ".astro"]);
@@ -24,18 +25,25 @@ function parseArgs(argv) {
 	return args;
 }
 
-function run(command) {
-	return execSync(command, { encoding: "utf8" }).trim();
+function isSafeRef(value) {
+	return SAFE_REF_PATTERN.test(value);
+}
+
+function runGit(args) {
+	return execFileSync("git", args, { encoding: "utf8" }).trim();
 }
 
 function listAllTrackedFiles() {
-	const out = run("git ls-files");
+	const out = runGit(["ls-files"]);
 	if (!out) return [];
 	return out.split("\n").filter(Boolean);
 }
 
 function listChangedFiles(base, head) {
-	const out = run(`git diff --name-only ${base}...${head}`);
+	if (!isSafeRef(base) || !isSafeRef(head)) {
+		throw new Error("Invalid git ref for --base or --head");
+	}
+	const out = runGit(["diff", "--name-only", `${base}...${head}`]);
 	if (!out) return [];
 	return out.split("\n").filter(Boolean);
 }
@@ -71,6 +79,9 @@ function checkFile(filePath) {
 
 function main() {
 	const { mode, base, head } = parseArgs(process.argv.slice(2));
+	if (mode !== "all" && mode !== "changed") {
+		throw new Error("Invalid --mode. Use 'all' or 'changed'.");
+	}
 	const files = mode === "all" ? listAllTrackedFiles() : listChangedFiles(base, head);
 	const targets = files.filter(isScannable);
 


### PR DESCRIPTION
## What does this PR do?

Implements issue #105 by removing shell-string command execution from `scripts/log-safety-check.mjs` and replacing it with argument-array git invocation plus ref validation.

Closes #105
Related: #103, #81

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `node scripts/log-safety-check.mjs --mode=changed --base=origin/main --head=HEAD` passed