### PR TITLE
fix: remediate insecure e2e temp-file usage

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -7,16 +7,13 @@
  */
 
 import { readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { test as base } from "@playwright/test";
 
 import { AdminPage } from "./admin";
+import { SERVER_INFO_PATH } from "./server-info-path";
 
 export { AdminPage } from "./admin";
-
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 
 interface ServerInfo {
 	pid: number;

--- a/e2e/fixtures/refresh-server-pat.ts
+++ b/e2e/fixtures/refresh-server-pat.ts
@@ -3,10 +3,7 @@
  * and the fixture database is back in "setup complete" state.
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
+import { SERVER_INFO_PATH } from "./server-info-path";
 
 export async function refreshServerPatAfterDevBypass(baseUrl: string): Promise<void> {
 	const res = await fetch(`${baseUrl}/_emdash/api/setup/dev-bypass?token=1`);

--- a/e2e/fixtures/server-info-path.ts
+++ b/e2e/fixtures/server-info-path.ts
@@ -1,0 +1,3 @@
+import { join, resolve } from "node:path";
+
+export const SERVER_INFO_PATH = resolve(join(process.cwd(), ".e2e", "emdash-pw-server.json"));

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -7,13 +7,14 @@
  */
 
 import { execFile, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { SMOKE_SEED_ITEMS } from "./fixtures/smoke-seed";
+import { SERVER_INFO_PATH } from "./fixtures/server-info-path";
 
 const execAsync = promisify(execFile);
 
@@ -24,8 +25,6 @@ const FIXTURE_DIR = resolve(ROOT, "e2e/fixture");
 const CLI_BINARY = resolve(ROOT, "packages/core/dist/cli/index.mjs");
 const PORT = 4444;
 const MARKETPLACE_PORT = 4445;
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
-
 // Regex patterns
 const COOKIE_VALUE_PATTERN = /^([^;]+)/;
 const TOKEN_PATTERN = /^[A-Za-z0-9._-]{20,300}$/;
@@ -331,6 +330,7 @@ export default async function globalSetup(): Promise<void> {
 			contentIds: seed.contentIds,
 			mediaIds: seed.mediaIds,
 		};
+		mkdirSync(dirname(SERVER_INFO_PATH), { recursive: true });
 		writeFileSync(SERVER_INFO_PATH, JSON.stringify(info, null, 2));
 
 		console.log(`[pw] Server ready at ${baseUrl} (pid ${server.pid})`);

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -6,11 +6,10 @@
  */
 
 import { existsSync, readFileSync, readdirSync, rmSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { SERVER_INFO_PATH } from "./fixtures/server-info-path";
 
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const FIXTURE_DIR = resolve(ROOT, "e2e/fixture");

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -17,18 +17,15 @@
  */
 
 import { readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { expect, test } from "../fixtures";
+import { SERVER_INFO_PATH } from "../fixtures/server-info-path";
 import { addVirtualWebAuthnAuthenticator } from "../fixtures/virtual-authenticator";
 
 // Regex patterns
 const ADMIN_URL_PATTERN = /\/_emdash\/admin/;
 const INVITE_URL_REGEX = /https?:\/\/[^\s]+\/admin\/invite\/accept\?token=[^\s]+/;
 const URL_IN_TEXT_REGEX = /https?:\/\/[^\s]+/;
-
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 
 function getServerInfo(): { baseUrl: string; token: string; sessionCookie: string } {
 	return JSON.parse(readFileSync(SERVER_INFO_PATH, "utf-8"));

--- a/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
+++ b/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
@@ -6,16 +6,13 @@
  */
 
 import { readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { expect, test } from "../fixtures";
 import { refreshServerPatAfterDevBypass } from "../fixtures/refresh-server-pat";
+import { SERVER_INFO_PATH } from "../fixtures/server-info-path";
 import { addVirtualWebAuthnAuthenticator } from "../fixtures/virtual-authenticator";
 
 const ADMIN_AFTER_SETUP_URL = /\/_emdash\/admin(\/login)?/;
-
-const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 
 function fixtureBaseUrl(): string {
 	return JSON.parse(readFileSync(SERVER_INFO_PATH, "utf-8")).baseUrl as string;


### PR DESCRIPTION
## What does this PR do?

Implements issue #104 by replacing tempdir-based shared file paths for Playwright server info with a workspace-scoped path and centralized constant.

Closes #104
Related: #103, #81

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `pnpm exec playwright test e2e/tests/invite-flow.spec.ts --project=chromium` ran with 8/9 passing; one existing flaky visibility assertion failure remains in `invited user appears in the users list`