### PR TITLE
fix: remediate remote property injection in blocks

### DIFF
--- a/packages/blocks/src/blocks/chart.tsx
+++ b/packages/blocks/src/blocks/chart.tsx
@@ -57,6 +57,10 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 	return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+function isUnsafeObjectKey(key: string): boolean {
+	return key === "__proto__" || key === "prototype" || key === "constructor";
+}
+
 const RE_HTML_TAG = /<[a-z/!]/i;
 
 function containsHtml(v: unknown): boolean {
@@ -72,6 +76,7 @@ function sanitizeOptions(obj: Record<string, unknown>): Record<string, unknown> 
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(obj)) {
 		if (DANGEROUS_KEYS.has(key)) continue;
+		if (isUnsafeObjectKey(key)) continue;
 		if (containsHtml(value)) {
 			result[key] = escapeHtml(value as string);
 		} else if (Array.isArray(value)) {

--- a/packages/blocks/src/blocks/form.tsx
+++ b/packages/blocks/src/blocks/form.tsx
@@ -4,6 +4,10 @@ import { useCallback, useState } from "react";
 import { renderElement } from "../render-element.js";
 import type { BlockInteraction, FieldCondition, FormBlock, FormField } from "../types.js";
 
+function isSafeActionKey(key: string): boolean {
+	return key !== "__proto__" && key !== "prototype" && key !== "constructor";
+}
+
 function deepEqual(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
 	if (Array.isArray(a) && Array.isArray(b)) {
@@ -14,6 +18,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 function evaluateCondition(condition: FieldCondition, values: Record<string, unknown>): boolean {
+	if (!isSafeActionKey(condition.field)) return false;
 	const fieldValue = values[condition.field];
 	if ("eq" in condition && condition.eq !== undefined) {
 		return deepEqual(fieldValue, condition.eq);
@@ -27,6 +32,7 @@ function evaluateCondition(condition: FieldCondition, values: Record<string, unk
 function getInitialValues(fields: FormField[]): Record<string, unknown> {
 	const values: Record<string, unknown> = {};
 	for (const field of fields) {
+		if (!isSafeActionKey(field.action_id)) continue;
 		if ("initial_value" in field && field.initial_value !== undefined) {
 			values[field.action_id] = field.initial_value;
 		}
@@ -46,6 +52,7 @@ export function FormBlockComponent({
 	);
 
 	const handleChange = useCallback((actionId: string, value: unknown) => {
+		if (!isSafeActionKey(actionId)) return;
 		setValues((prev) => ({ ...prev, [actionId]: value }));
 	}, []);
 


### PR DESCRIPTION
## What does this PR do?

Implements issue #106 by hardening dynamic object key writes in blocks rendering paths to prevent prototype pollution style writes.

Closes #106
Related: #103, #81

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `pnpm --filter @emdash-cms/blocks typecheck` passed