### PR TITLE
fix: constrain file-backed outbound network targets

### DIFF
--- a/packages/core/src/cli/commands/publish.ts
+++ b/packages/core/src/cli/commands/publish.ts
@@ -29,6 +29,22 @@ import {
 } from "../credentials.js";
 
 const DEFAULT_REGISTRY = "https://marketplace.emdashcms.com";
+const SAFE_PLUGIN_ID_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+function normalizeRegistryUrl(input: string): string {
+	const url = new URL(input);
+	const isLocalhost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalhost)) {
+		throw new Error("Registry URL must use HTTPS (or localhost HTTP)");
+	}
+	return url.toString();
+}
+
+function assertSafePluginId(pluginId: string): void {
+	if (!SAFE_PLUGIN_ID_PATTERN.test(pluginId)) {
+		throw new Error(`Unsafe plugin id: ${pluginId}`);
+	}
+}
 
 // ── GitHub Device Flow ──────────────────────────────────────────
 
@@ -371,7 +387,7 @@ export const publishCommand = defineCommand({
 		},
 	},
 	async run({ args }) {
-		const registryUrl = args.registry;
+		const registryUrl = normalizeRegistryUrl(args.registry);
 
 		// ── Step 1: Resolve tarball ──
 
@@ -431,6 +447,7 @@ export const publishCommand = defineCommand({
 		// ── Step 2: Read manifest from tarball ──
 
 		const manifest = await readManifestFromTarball(tarballPath);
+		assertSafePluginId(manifest.id);
 		console.log();
 		consola.info(`Plugin: ${pc.bold(`${manifest.id}@${manifest.version}`)}`);
 		if (manifest.capabilities.length > 0) {

--- a/packages/core/src/client/transport.ts
+++ b/packages/core/src/client/transport.ts
@@ -142,9 +142,14 @@ export function refreshInterceptor(options: {
 	onTokenRefreshed?: (accessToken: string, refreshToken: string, expiresAt: string) => void;
 }): Interceptor {
 	let refreshing: Promise<string | null> | null = null;
+	const tokenEndpoint = new URL(options.tokenEndpoint);
+	const isLocalhost = tokenEndpoint.hostname === "localhost" || tokenEndpoint.hostname === "127.0.0.1";
+	if (tokenEndpoint.protocol !== "https:" && !(tokenEndpoint.protocol === "http:" && isLocalhost)) {
+		throw new Error("Token endpoint must use HTTPS (or localhost HTTP)");
+	}
 
 	async function refresh(): Promise<string | null> {
-		const res = await globalThis.fetch(options.tokenEndpoint, {
+		const res = await globalThis.fetch(tokenEndpoint, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({

--- a/scripts/query-counts.mjs
+++ b/scripts/query-counts.mjs
@@ -65,6 +65,13 @@ const ROUTES = JSON.parse(readFileSync(routesConfigPath, "utf8")).map((route) =>
 const TRACKED_PHASES = new Set(["cold", "warm"]);
 const VALID_TARGETS = new Set(["sqlite", "d1"]);
 const QUERY_LOG_PREFIX = "[emdash-query-log] ";
+const SAFE_ROUTE_PATH_PATTERN = /^\/[A-Za-z0-9/_-]*$/;
+
+function assertSafeRoutePath(routePath) {
+	if (!SAFE_ROUTE_PATH_PATTERN.test(routePath)) {
+		throw new Error(`Unsafe route path in query-counts.routes.json: ${routePath}`);
+	}
+}
 
 /**
  * Resolve once a TCP connection to (host, port) succeeds, or reject on
@@ -309,6 +316,7 @@ async function hit(method, path, phase) {
 	let lastErr;
 	for (let i = 0; i < 10; i++) {
 		try {
+			assertSafeRoutePath(path);
 			const r = await fetch(`${BASE}${path}`, {
 				method,
 				headers: { "x-perf-phase": phase },


### PR DESCRIPTION
## What does this PR do?

Implements issue #107 by adding explicit endpoint/path validation around outbound requests that consume file-backed values in transport, publish, and query-count tooling.

Closes #107
Related: #103, #81

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode)

## Screenshots / test output

- `pnpm --silent lint:quick` passed
- `pnpm --filter emdash typecheck` passed