### PR TITLE
fix: harden CLI browser opener against command injection

### DIFF
--- a/packages/core/src/cli/commands/login.ts
+++ b/packages/core/src/cli/commands/login.ts
@@ -29,6 +29,7 @@ import {
 	resolveCredentialKey,
 	saveCredentials,
 } from "../credentials.js";
+import { getOpenExternalUrlCommand } from "../open-external-url.js";
 import { configureOutputMode } from "../output.js";
 
 // ---------------------------------------------------------------------------
@@ -293,12 +294,12 @@ export const loginCommand = defineCommand({
 			// Try to open browser (best-effort)
 			try {
 				const { execFile } = await import("node:child_process");
-				if (process.platform === "darwin") {
-					execFile("open", [deviceCode.verification_uri]);
-				} else if (process.platform === "win32") {
-					execFile("cmd", ["/c", "start", "", deviceCode.verification_uri]);
-				} else {
-					execFile("xdg-open", [deviceCode.verification_uri]);
+				const openCommand = getOpenExternalUrlCommand(
+					process.platform,
+					deviceCode.verification_uri,
+				);
+				if (openCommand) {
+					execFile(openCommand.command, openCommand.args);
 				}
 			} catch {
 				// Ignore — user can open manually

--- a/packages/core/src/cli/commands/publish.ts
+++ b/packages/core/src/cli/commands/publish.ts
@@ -27,6 +27,7 @@ import {
 	saveMarketplaceCredential,
 	removeMarketplaceCredential,
 } from "../credentials.js";
+import { getOpenExternalUrlCommand } from "../open-external-url.js";
 
 const DEFAULT_REGISTRY = "https://marketplace.emdashcms.com";
 const SAFE_PLUGIN_ID_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
@@ -127,12 +128,9 @@ async function authenticateViaDeviceFlow(registryUrl: string): Promise<Marketpla
 	// Try to open browser
 	try {
 		const { execFile } = await import("node:child_process");
-		if (process.platform === "darwin") {
-			execFile("open", [deviceCode.verification_uri]);
-		} else if (process.platform === "win32") {
-			execFile("cmd", ["/c", "start", "", deviceCode.verification_uri]);
-		} else {
-			execFile("xdg-open", [deviceCode.verification_uri]);
+		const openCommand = getOpenExternalUrlCommand(process.platform, deviceCode.verification_uri);
+		if (openCommand) {
+			execFile(openCommand.command, openCommand.args);
 		}
 	} catch {
 		// User can open manually

--- a/packages/core/src/cli/open-external-url.ts
+++ b/packages/core/src/cli/open-external-url.ts
@@ -1,0 +1,35 @@
+interface OpenCommand {
+	command: string;
+	args: string[];
+}
+
+function isAllowedExternalUrl(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return parsed.protocol === "https:" || parsed.protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
+export function getOpenExternalUrlCommand(
+	platform: NodeJS.Platform,
+	url: string,
+): OpenCommand | null {
+	if (!isAllowedExternalUrl(url)) {
+		return null;
+	}
+
+	if (platform === "darwin") {
+		return { command: "open", args: [url] };
+	}
+
+	if (platform === "win32") {
+		return {
+			command: "rundll32.exe",
+			args: ["url.dll,FileProtocolHandler", url],
+		};
+	}
+
+	return { command: "xdg-open", args: [url] };
+}

--- a/packages/core/tests/unit/cli/open-external-url.test.ts
+++ b/packages/core/tests/unit/cli/open-external-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getOpenExternalUrlCommand } from "../../../src/cli/open-external-url.js";
+
+describe("getOpenExternalUrlCommand", () => {
+	it("returns macOS open command for https urls", () => {
+		expect(getOpenExternalUrlCommand("darwin", "https://example.com/verify")).toEqual({
+			command: "open",
+			args: ["https://example.com/verify"],
+		});
+	});
+
+	it("returns Windows rundll32 command for http urls", () => {
+		expect(getOpenExternalUrlCommand("win32", "http://localhost:4321/dev")).toEqual({
+			command: "rundll32.exe",
+			args: ["url.dll,FileProtocolHandler", "http://localhost:4321/dev"],
+		});
+	});
+
+	it("returns xdg-open command for linux-like platforms", () => {
+		expect(getOpenExternalUrlCommand("linux", "https://example.com/verify")).toEqual({
+			command: "xdg-open",
+			args: ["https://example.com/verify"],
+		});
+	});
+
+	it("rejects non-http schemes", () => {
+		expect(getOpenExternalUrlCommand("darwin", "javascript:alert(1)")).toBeNull();
+		expect(getOpenExternalUrlCommand("win32", "file:///etc/passwd")).toBeNull();
+	});
+
+	it("rejects invalid urls", () => {
+		expect(getOpenExternalUrlCommand("linux", "not-a-url")).toBeNull();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Replaces shell-mediated Windows browser launching in CLI auth flows with a validated URL opener helper that only allows HTTP(S) URLs and uses direct executable invocations. This addresses remaining CodeQL `js/command-line-injection` findings in login/publish device-flow paths.

Closes #112

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Added unit tests for opener command mapping and invalid URL rejection in `packages/core/tests/unit/cli/open-external-url.test.ts`.
