### PR TITLE
fix: harden blocks against remote property injection

### DIFF
--- a/packages/blocks/src/blocks/chart.tsx
+++ b/packages/blocks/src/blocks/chart.tsx
@@ -61,6 +61,16 @@ function isUnsafeObjectKey(key: string): boolean {
 	return key === "__proto__" || key === "prototype" || key === "constructor";
 }
 
+function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
+	if (isUnsafeObjectKey(key)) return;
+	Object.defineProperty(target, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}
+
 const RE_HTML_TAG = /<[a-z/!]/i;
 
 function containsHtml(v: unknown): boolean {
@@ -78,19 +88,23 @@ function sanitizeOptions(obj: Record<string, unknown>): Record<string, unknown> 
 		if (DANGEROUS_KEYS.has(key)) continue;
 		if (isUnsafeObjectKey(key)) continue;
 		if (containsHtml(value)) {
-			result[key] = escapeHtml(value as string);
+			safeSet(result, key, escapeHtml(value as string));
 		} else if (Array.isArray(value)) {
-			result[key] = value.map((item) =>
+			safeSet(
+				result,
+				key,
+				value.map((item) =>
 				isRecord(item)
 					? sanitizeOptions(item)
 					: containsHtml(item)
 						? escapeHtml(item as string)
 						: item,
+				),
 			);
 		} else if (isRecord(value)) {
-			result[key] = sanitizeOptions(value);
+			safeSet(result, key, sanitizeOptions(value));
 		} else {
-			result[key] = value;
+			safeSet(result, key, value);
 		}
 	}
 	return result;

--- a/packages/blocks/src/blocks/form.tsx
+++ b/packages/blocks/src/blocks/form.tsx
@@ -8,6 +8,16 @@ function isSafeActionKey(key: string): boolean {
 	return key !== "__proto__" && key !== "prototype" && key !== "constructor";
 }
 
+function safeSetValue(target: Record<string, unknown>, key: string, value: unknown): void {
+	if (!isSafeActionKey(key)) return;
+	Object.defineProperty(target, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}
+
 function deepEqual(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
 	if (Array.isArray(a) && Array.isArray(b)) {
@@ -30,11 +40,11 @@ function evaluateCondition(condition: FieldCondition, values: Record<string, unk
 }
 
 function getInitialValues(fields: FormField[]): Record<string, unknown> {
-	const values: Record<string, unknown> = {};
+	const values: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
 	for (const field of fields) {
 		if (!isSafeActionKey(field.action_id)) continue;
 		if ("initial_value" in field && field.initial_value !== undefined) {
-			values[field.action_id] = field.initial_value;
+			safeSetValue(values, field.action_id, field.initial_value);
 		}
 	}
 	return values;
@@ -53,7 +63,11 @@ export function FormBlockComponent({
 
 	const handleChange = useCallback((actionId: string, value: unknown) => {
 		if (!isSafeActionKey(actionId)) return;
-		setValues((prev) => ({ ...prev, [actionId]: value }));
+		setValues((prev) => {
+			const next = { ...prev };
+			safeSetValue(next, actionId, value);
+			return next;
+		});
 	}, []);
 
 	function handleSubmit(e: React.FormEvent) {

--- a/packages/blocks/tests/form-conditions.test.tsx
+++ b/packages/blocks/tests/form-conditions.test.tsx
@@ -400,4 +400,30 @@ describe("form conditional fields", () => {
 		// Toggle B is false → Field B hidden
 		expect(screen.queryByText("Field B")).toBeNull();
 	});
+
+	it("ignores unsafe action keys to prevent prototype mutation", () => {
+		const onAction = vi.fn();
+		renderForm(
+			{
+				type: "form",
+				fields: [
+					{
+						type: "text_input",
+						action_id: "__proto__",
+						label: "Danger",
+						initial_value: "polluted",
+					},
+				],
+				submit: { label: "Save", action_id: "save" },
+			},
+			onAction,
+		);
+
+		fireEvent.click(screen.getByText("Save"));
+		expect(onAction).toHaveBeenCalledTimes(1);
+		const payload = onAction.mock.calls[0]?.[0] as BlockInteraction;
+		expect(payload.type).toBe("form_submit");
+		expect(Object.prototype.hasOwnProperty.call(payload.values, "__proto__")).toBe(false);
+		expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Hardens dynamic key assignment in `@emdash-cms/blocks` form/chart rendering paths by routing writes through guarded defineProperty helpers and rejecting unsafe keys (`__proto__`, `prototype`, `constructor`). Also adds a regression test covering unsafe action keys in form submission payloads.

Closes #114

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Added unsafe-key regression in `packages/blocks/tests/form-conditions.test.tsx`.
