### PR TITLE
fix: harden login redirects and image block URLs

### DIFF
--- a/packages/admin/src/components/LoginPage.tsx
+++ b/packages/admin/src/components/LoginPage.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 
 import { apiFetch, fetchAuthMode } from "../lib/api";
 import { useAuthProviderList } from "../lib/auth-provider-context";
-import { sanitizeRedirectUrl } from "../lib/url";
+import { isSafeRedirectPath, sanitizeRedirectUrl } from "../lib/url";
 import { SUPPORTED_LOCALES } from "../locales/index.js";
 import { useLocale } from "../locales/useLocale.js";
 import { PasskeyLogin } from "./auth/PasskeyLogin";
@@ -163,6 +163,11 @@ function MagicLinkForm({ onBack }: MagicLinkFormProps) {
 export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 	// Defense-in-depth: sanitize even if the caller already validated
 	const safeRedirectUrl = sanitizeRedirectUrl(redirectUrl);
+	const navigateToSafeRedirect = React.useCallback(() => {
+		if (!isSafeRedirectPath(safeRedirectUrl)) return;
+		const next = new URL(safeRedirectUrl, window.location.origin);
+		window.location.assign(`${next.pathname}${next.search}${next.hash}`);
+	}, [safeRedirectUrl]);
 	const { t } = useLingui();
 	const { locale, setLocale } = useLocale();
 	const [method, setMethod] = React.useState<LoginMethod>("passkey");
@@ -181,9 +186,9 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 	// Redirect to admin when using external auth (authentication is handled externally)
 	React.useEffect(() => {
 		if (authInfo?.authMode && authInfo.authMode !== "passkey") {
-			window.location.href = safeRedirectUrl;
+			navigateToSafeRedirect();
 		}
-	}, [authInfo, safeRedirectUrl]);
+	}, [authInfo, navigateToSafeRedirect]);
 
 	// Check for error in URL (from OAuth/provider redirect)
 	React.useEffect(() => {
@@ -200,7 +205,7 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 
 	const handleSuccess = () => {
 		// Redirect after successful login
-		window.location.href = safeRedirectUrl;
+		navigateToSafeRedirect();
 	};
 
 	// All providers with a LoginButton show in the button grid

--- a/packages/admin/src/lib/url.ts
+++ b/packages/admin/src/lib/url.ts
@@ -22,6 +22,13 @@ export function sanitizeRedirectUrl(raw: string): string {
 }
 
 /**
+ * Returns true only for internal path-style redirects.
+ */
+export function isSafeRedirectPath(raw: string): boolean {
+	return raw.startsWith("/") && !raw.startsWith("//") && !raw.includes("\\");
+}
+
+/**
  * Build a public content URL from collection metadata and slug.
  *
  * Uses the collection's `urlPattern` when available (e.g. `/blog/{slug}`),

--- a/packages/admin/tests/lib/url.test.ts
+++ b/packages/admin/tests/lib/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { sanitizeRedirectUrl } from "../../src/lib/url";
+import { isSafeRedirectPath, sanitizeRedirectUrl } from "../../src/lib/url";
 
 describe("sanitizeRedirectUrl", () => {
 	it("allows simple relative paths", () => {
@@ -55,5 +55,22 @@ describe("sanitizeRedirectUrl", () => {
 
 	it("rejects bare domain", () => {
 		expect(sanitizeRedirectUrl("evil.com")).toBe("/_emdash/admin");
+	});
+});
+
+describe("isSafeRedirectPath", () => {
+	it("accepts internal paths", () => {
+		expect(isSafeRedirectPath("/_emdash/admin")).toBe(true);
+		expect(isSafeRedirectPath("/_emdash/admin?tab=settings#content")).toBe(true);
+	});
+
+	it("rejects protocol-relative and escaped paths", () => {
+		expect(isSafeRedirectPath("//evil.com")).toBe(false);
+		expect(isSafeRedirectPath("/\\evil.com")).toBe(false);
+	});
+
+	it("rejects non-path urls", () => {
+		expect(isSafeRedirectPath("https://evil.com")).toBe(false);
+		expect(isSafeRedirectPath("javascript:alert(1)")).toBe(false);
 	});
 });

--- a/packages/blocks/src/blocks/image.tsx
+++ b/packages/blocks/src/blocks/image.tsx
@@ -1,9 +1,29 @@
 import type { ImageBlock } from "../types.js";
 
+function safeImageUrl(raw: string): string | undefined {
+	if (raw.startsWith("/") && !raw.startsWith("//") && !raw.includes("\\")) {
+		return raw;
+	}
+
+	try {
+		const parsed = new URL(raw);
+		if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+			return parsed.toString();
+		}
+	} catch {
+		return undefined;
+	}
+
+	return undefined;
+}
+
 export function ImageBlockComponent({ block }: { block: ImageBlock }) {
+	const src = safeImageUrl(block.url);
+	if (!src) return null;
+
 	return (
 		<figure>
-			<img src={block.url} alt={block.alt} className="max-w-full rounded" />
+			<img src={src} alt={block.alt} className="max-w-full rounded" />
 			{block.title && (
 				<figcaption className="mt-1 text-sm text-kumo-subtle">{block.title}</figcaption>
 			)}


### PR DESCRIPTION
## What does this PR do?

Hardens client-side URL sinks identified by CodeQL `js/client-side-unvalidated-url-redirection` by enforcing internal-path-only login redirects and sanitizing image block URLs before assigning to `img.src`.

Closes #116

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Scope-limited security hardening only; no UI screenshots.
