### PR TITLE
fix: use parser-based caption/text extraction

### DIFF
--- a/packages/gutenberg-to-portable-text/src/index.ts
+++ b/packages/gutenberg-to-portable-text/src/index.ts
@@ -8,7 +8,7 @@
 
 import { parse } from "@wordpress/block-serialization-default-parser";
 
-import { parseInlineContent } from "./inline.js";
+import { extractText, parseInlineContent } from "./inline.js";
 import { getTransformer } from "./transformers/index.js";
 import type {
 	GutenbergBlock,
@@ -27,7 +27,6 @@ const SRC_ATTR_PATTERN = /src=["']([^"']+)["']/i;
 const ALT_ATTR_PATTERN = /alt=["']([^"']*)["']/i;
 const LIST_ITEM_PATTERN = /<li[^>]*>([\s\S]*?)<\/li>/gu;
 const CODE_TAG_PATTERN = /<code[^>]*>([\s\S]*?)<\/code>/i;
-const HTML_TAG_PATTERN = /<[^>]+>/g;
 const FIGCAPTION_TAG_PATTERN = /<figcaption[^>]*>([\s\S]*?)<\/figcaption>/i;
 const AMP_ENTITY_PATTERN = /&amp;/g;
 const LESS_THAN_ENTITY_PATTERN = /&lt;/g;
@@ -376,7 +375,7 @@ export function htmlToPortableText(
 							url: imgUrl || undefined,
 						},
 						alt: altMatch?.[1],
-						caption: captionMatch?.[1]?.replace(HTML_TAG_PATTERN, "").trim(),
+						caption: captionMatch?.[1] ? extractText(captionMatch[1]) : undefined,
 					});
 				}
 				break;

--- a/packages/gutenberg-to-portable-text/tests/converter.test.ts
+++ b/packages/gutenberg-to-portable-text/tests/converter.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 
 import { gutenbergToPortableText, htmlToPortableText, parseGutenbergBlocks } from "../src/index.js";
+import { extractText } from "../src/inline.js";
 import type {
 	PortableTextTextBlock,
 	PortableTextImageBlock,
@@ -14,7 +15,6 @@ import type {
 	PortableTextCoverBlock,
 } from "../src/types.js";
 
-const HTML_TAG_PATTERN = /<[^>]+>/g;
 const knownProviders = [
 	["youtube.com", "youtube"],
 	["youtu.be", "youtube"],
@@ -1023,7 +1023,7 @@ https://${domain}/123456
 						{
 							_type: "testimonial" as const,
 							_key: ctx.generateKey(),
-							text: block.innerHTML.replace(HTML_TAG_PATTERN, "").trim(),
+						text: extractText(block.innerHTML),
 							rating: block.attrs.rating as number,
 						} as unknown as import("../src/types.js").PortableTextBlock,
 					],


### PR DESCRIPTION
## What does this PR do?

Replaces regex-based HTML tag stripping in Gutenberg converter paths with parser-based extraction (`extractText`) to address CodeQL `js/incomplete-multi-character-sanitization` findings.

Closes #118

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Behavior-preserving security hardening in converter + test fixture.
