### PR TITLE
fix: use hostname-based embed provider detection

### DIFF
--- a/packages/gutenberg-to-portable-text/src/transformers/embed.ts
+++ b/packages/gutenberg-to-portable-text/src/transformers/embed.ts
@@ -105,38 +105,51 @@ export const audio: BlockTransformer = (block, _options, context) => {
 function detectProvider(url: string): string | undefined {
 	if (!url) return undefined;
 
-	const urlLower = url.toLowerCase();
+	const host = getLowercaseHostname(url);
+	if (!host) return undefined;
 
-	if (urlLower.includes("youtube.com") || urlLower.includes("youtu.be")) {
+	if (hostMatches(host, "youtube.com") || hostMatches(host, "youtu.be")) {
 		return "youtube";
 	}
-	if (urlLower.includes("vimeo.com")) {
+	if (hostMatches(host, "vimeo.com")) {
 		return "vimeo";
 	}
-	if (urlLower.includes("twitter.com") || urlLower.includes("x.com")) {
+	if (hostMatches(host, "twitter.com") || hostMatches(host, "x.com")) {
 		return "twitter";
 	}
-	if (urlLower.includes("instagram.com")) {
+	if (hostMatches(host, "instagram.com")) {
 		return "instagram";
 	}
-	if (urlLower.includes("facebook.com")) {
+	if (hostMatches(host, "facebook.com")) {
 		return "facebook";
 	}
-	if (urlLower.includes("tiktok.com")) {
+	if (hostMatches(host, "tiktok.com")) {
 		return "tiktok";
 	}
-	if (urlLower.includes("spotify.com")) {
+	if (hostMatches(host, "spotify.com")) {
 		return "spotify";
 	}
-	if (urlLower.includes("soundcloud.com")) {
+	if (hostMatches(host, "soundcloud.com")) {
 		return "soundcloud";
 	}
-	if (urlLower.includes("codepen.io")) {
+	if (hostMatches(host, "codepen.io")) {
 		return "codepen";
 	}
-	if (urlLower.includes("gist.github.com")) {
+	if (hostMatches(host, "gist.github.com")) {
 		return "gist";
 	}
 
 	return undefined;
+}
+
+function getLowercaseHostname(rawUrl: string): string | undefined {
+	try {
+		return new URL(rawUrl).hostname.toLowerCase();
+	} catch {
+		return undefined;
+	}
+}
+
+function hostMatches(hostname: string, expectedHost: string): boolean {
+	return hostname === expectedHost || hostname.endsWith(`.${expectedHost}`);
 }

--- a/packages/gutenberg-to-portable-text/tests/converter.test.ts
+++ b/packages/gutenberg-to-portable-text/tests/converter.test.ts
@@ -521,6 +521,40 @@ https://${domain}/123456
 			},
 		);
 
+		it("does not match provider on lookalike hostnames", () => {
+			const content = `<!-- wp:embed {"url":"https://youtube.com.evil.example/123456"} -->
+<figure class="wp-block-embed">
+<div class="wp-block-embed__wrapper">
+https://youtube.com.evil.example/123456
+</div>
+</figure>
+<!-- /wp:embed -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({
+				_type: "embed",
+				provider: undefined,
+			});
+		});
+
+		it("does not match provider when hostname only contains provider substring", () => {
+			const content = `<!-- wp:embed {"url":"https://evilyoutube.com/123456"} -->
+<figure class="wp-block-embed">
+<div class="wp-block-embed__wrapper">
+https://evilyoutube.com/123456
+</div>
+</figure>
+<!-- /wp:embed -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({
+				_type: "embed",
+				provider: undefined,
+			});
+		});
+
 		it("converts audio embeds", () => {
 			const content = `<!-- wp:audio {"src":"https://example.com/audio.mp3"} -->
 <audio controls src="https://example.com/audio.mp3"></audio>


### PR DESCRIPTION
## What does this PR do?

Replaces substring-based provider detection for Gutenberg embeds with URL hostname parsing and exact/suffix host matching. This fixes CodeQL `js/incomplete-url-substring-sanitization` findings where lookalike hostnames could be misclassified.

Closes #120

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Added regression tests for lookalike-host provider detection.
