### PR TITLE
fix: prevent prototype-polluting assignments in field-kit

### DIFF
--- a/packages/plugins/field-kit/src/shared/utils.ts
+++ b/packages/plugins/field-kit/src/shared/utils.ts
@@ -1,5 +1,9 @@
 import type { SubFieldDef, GridAxisDef } from "./types";
 
+function isUnsafeKey(key: string): boolean {
+	return key === "__proto__" || key === "prototype" || key === "constructor";
+}
+
 /**
  * Normalize a value into a plain object keyed by sub-field definitions.
  * Missing declared keys get their defaultValue (or undefined). Keys present
@@ -14,6 +18,7 @@ export function normalizeObject(value: unknown, fields: SubFieldDef[]): Record<s
 			: {};
 	const obj: Record<string, unknown> = { ...source };
 	for (const field of fields) {
+		if (isUnsafeKey(field.key)) continue;
 		if (source[field.key] === undefined) {
 			obj[field.key] = field.defaultValue ?? undefined;
 		}
@@ -42,6 +47,7 @@ export function normalizeGrid(
 ): Record<string, Record<string, unknown>> {
 	const out: Record<string, Record<string, unknown>> = {};
 	for (const row of rows) {
+		if (isUnsafeKey(row.key)) continue;
 		out[row.key] = {};
 	}
 
@@ -51,12 +57,13 @@ export function normalizeGrid(
 
 	const source = value as Record<string, unknown>;
 	for (const row of rows) {
+		if (isUnsafeKey(row.key)) continue;
 		const rowVal = source[row.key];
 		const rowOut = out[row.key]!;
 		if (Array.isArray(rowVal)) {
 			// Legacy array format: convert ["leaf", "fruit"] → { leaf: true, fruit: true }
 			for (const code of rowVal) {
-				if (typeof code === "string") {
+				if (typeof code === "string" && !isUnsafeKey(code)) {
 					rowOut[code] = true;
 				}
 			}
@@ -65,8 +72,12 @@ export function normalizeGrid(
 			// over them. Unknown keys survive so cells added to the schema later
 			// or managed outside this widget aren't silently dropped on save.
 			const rowObj = rowVal as Record<string, unknown>;
-			Object.assign(rowOut, rowObj);
+			for (const [cellKey, cellValue] of Object.entries(rowObj)) {
+				if (isUnsafeKey(cellKey)) continue;
+				rowOut[cellKey] = cellValue;
+			}
 			for (const col of columns) {
+				if (isUnsafeKey(col.key)) continue;
 				if (rowObj[col.key] !== undefined) {
 					rowOut[col.key] = rowObj[col.key];
 				}

--- a/packages/plugins/field-kit/tests/grid.test.tsx
+++ b/packages/plugins/field-kit/tests/grid.test.tsx
@@ -152,6 +152,26 @@ describe("Grid widget", () => {
 		});
 	});
 
+	it("drops unsafe prototype keys from incoming grid object data", () => {
+		const onChange = vi.fn();
+		render(
+			<Grid
+				value={{ mon: { am: true, __proto__: { polluted: true } as unknown } }}
+				onChange={onChange}
+				label="Grid"
+				id="g"
+				options={{ rows, columns }}
+			/>,
+		);
+
+		fireEvent.click(screen.getByLabelText("Mon — PM"));
+		expect(onChange).toHaveBeenCalledWith({
+			mon: { am: true, pm: true },
+			tue: {},
+		});
+		expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+	});
+
 	it("shows misconfigured warning when rows or columns are missing", () => {
 		render(
 			<Grid


### PR DESCRIPTION
## What does this PR do?

Hardens `field-kit` grid/object normalization against prototype-polluting assignments by rejecting unsafe keys and replacing broad object assignment with guarded key-by-key copying.

Closes #122

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Added regression test for unsafe `__proto__` keys in `packages/plugins/field-kit/tests/grid.test.tsx`.
