### PR TITLE
fix: tighten core object guard checks

### DIFF
--- a/packages/core/src/plugins/define-plugin.ts
+++ b/packages/core/src/plugins/define-plugin.ts
@@ -247,7 +247,7 @@ function isHookConfig<THandler>(
 	if (typeof hook !== "object" || hook === null) {
 		return false;
 	}
-	return Object.hasOwn(hook, "handler");
+	return Object.prototype.hasOwnProperty.call(hook, "handler");
 }
 
 /**

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -940,7 +940,7 @@ export class SchemaRegistry {
 				text = String(value);
 				break;
 			case "object":
-				text = value === null ? "" : JSON.stringify(value);
+				text = value === null ? "" : (JSON.stringify(value) ?? "");
 				break;
 			default:
 				text = "";

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -72,7 +72,7 @@ function isMediaReference(value: unknown): value is MediaReference {
 	if (typeof value !== "object" || value === null) {
 		return false;
 	}
-	return Object.hasOwn(value, "mediaId");
+	return Object.prototype.hasOwnProperty.call(value, "mediaId");
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Applies small, atomic hardening for CodeQL `js/comparison-between-incompatible-types` findings in core guard paths by using explicit own-property calls on validated objects and null-safe JSON stringification fallback.

Closes #124

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Scope-limited security/type hardening; no visual impact.
