### PR TITLE
fix: reuse single tarball buffer during publish

### DIFF
--- a/packages/core/src/cli/commands/publish.ts
+++ b/packages/core/src/cli/commands/publish.ts
@@ -12,7 +12,7 @@
  * 6. Display audit results
  */
 
-import { readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { resolve, basename } from "node:path";
 
 import { defineCommand } from "citty";
@@ -227,8 +227,7 @@ type ManifestSummary = typeof manifestSummarySchema._zod.output;
 /**
  * Read manifest.json from a tarball without fully extracting it.
  */
-async function readManifestFromTarball(tarballPath: string): Promise<ManifestSummary> {
-	const data = await readFile(tarballPath);
+async function readManifestFromTarball(data: Buffer): Promise<ManifestSummary> {
 	const stream = new ReadableStream<Uint8Array>({
 		start(controller) {
 			controller.enqueue(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
@@ -438,13 +437,13 @@ export const publishCommand = defineCommand({
 			}
 		}
 
-		const tarballStat = await stat(tarballPath);
-		const sizeKB = (tarballStat.size / 1024).toFixed(1);
+		const tarballData = await readFile(tarballPath);
+		const sizeKB = (tarballData.byteLength / 1024).toFixed(1);
 		consola.info(`Tarball: ${pc.dim(tarballPath)} (${sizeKB}KB)`);
 
 		// ── Step 2: Read manifest from tarball ──
 
-		const manifest = await readManifestFromTarball(tarballPath);
+		const manifest = await readManifestFromTarball(tarballData);
 		assertSafePluginId(manifest.id);
 		console.log();
 		consola.info(`Plugin: ${pc.bold(`${manifest.id}@${manifest.version}`)}`);
@@ -561,7 +560,6 @@ export const publishCommand = defineCommand({
 
 		consola.start(`Publishing ${manifest.id}@${manifest.version}...`);
 
-		const tarballData = await readFile(tarballPath);
 		const formData = new FormData();
 		formData.append(
 			"bundle",


### PR DESCRIPTION
## What does this PR do?

Fixes CodeQL `js/file-system-race` in the publish CLI flow by reading the tarball once and reusing that same buffer for size reporting, manifest extraction, and upload.

Closes #126

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening only.
