### PR TITLE
fix: validate Cloudflare Access redirects via URL parsing

### DIFF
--- a/packages/core/src/client/cf-access.ts
+++ b/packages/core/src/client/cf-access.ts
@@ -144,7 +144,21 @@ export function createHeaderAwareFetch(headers: Record<string, string>): typeof 
 // Cloudflare Access detection
 // ---------------------------------------------------------------------------
 
-const ACCESS_LOGIN_PATTERN = /cloudflareaccess\.com\/cdn-cgi\/access\/login/;
+const ACCESS_LOGIN_HOST = "cloudflareaccess.com";
+const ACCESS_LOGIN_PATH = "/cdn-cgi/access/login";
+
+function isCloudflareAccessLoginUrl(location: string): boolean {
+	try {
+		const parsed = new URL(location);
+		const host = parsed.hostname.toLowerCase();
+		if (host !== ACCESS_LOGIN_HOST && !host.endsWith(`.${ACCESS_LOGIN_HOST}`)) {
+			return false;
+		}
+		return parsed.pathname === ACCESS_LOGIN_PATH;
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Check whether a response (fetched with `redirect: "manual"`) is a
@@ -153,7 +167,7 @@ const ACCESS_LOGIN_PATTERN = /cloudflareaccess\.com\/cdn-cgi\/access\/login/;
 export function isAccessRedirect(response: Response): boolean {
 	if (response.status !== 301 && response.status !== 302) return false;
 	const location = response.headers.get("location") ?? "";
-	return ACCESS_LOGIN_PATTERN.test(location);
+	return isCloudflareAccessLoginUrl(location);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes CodeQL `js/regex/missing-regexp-anchor` by replacing unanchored regex matching in Cloudflare Access redirect detection with URL parsing and strict host/path validation.

Closes #128

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening only.
