### PR TITLE
test: harden e2e fixture URL construction

### DIFF
--- a/e2e/fixtures/refresh-server-pat.ts
+++ b/e2e/fixtures/refresh-server-pat.ts
@@ -3,10 +3,14 @@
  * and the fixture database is back in "setup complete" state.
  */
 import { readFileSync, writeFileSync } from "node:fs";
+import { buildFromBase, parseSafeHttpBaseUrl } from "./safe-base-url";
 import { SERVER_INFO_PATH } from "./server-info-path";
 
 export async function refreshServerPatAfterDevBypass(baseUrl: string): Promise<void> {
-	const res = await fetch(`${baseUrl}/_emdash/api/setup/dev-bypass?token=1`);
+	const safeBase = parseSafeHttpBaseUrl(baseUrl);
+	const url = buildFromBase(safeBase, "/_emdash/api/setup/dev-bypass");
+	url.searchParams.set("token", "1");
+	const res = await fetch(url);
 	if (!res.ok) {
 		throw new Error(`dev-bypass failed (${res.status}): ${await res.text()}`);
 	}

--- a/e2e/fixtures/safe-base-url.ts
+++ b/e2e/fixtures/safe-base-url.ts
@@ -1,0 +1,14 @@
+export function parseSafeHttpBaseUrl(raw: string): URL {
+	const parsed = new URL(raw);
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new Error(`Unsafe base URL protocol: ${parsed.protocol}`);
+	}
+	return parsed;
+}
+
+export function buildFromBase(base: URL, path: string): URL {
+	if (!path.startsWith("/")) {
+		throw new Error(`Path must start with '/': ${path}`);
+	}
+	return new URL(path, base);
+}

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -19,6 +19,7 @@
 import { readFileSync } from "node:fs";
 
 import { expect, test } from "../fixtures";
+import { buildFromBase, parseSafeHttpBaseUrl } from "../fixtures/safe-base-url";
 import { SERVER_INFO_PATH } from "../fixtures/server-info-path";
 import { addVirtualWebAuthnAuthenticator } from "../fixtures/virtual-authenticator";
 
@@ -29,6 +30,10 @@ const URL_IN_TEXT_REGEX = /https?:\/\/[^\s]+/;
 
 function getServerInfo(): { baseUrl: string; token: string; sessionCookie: string } {
 	return JSON.parse(readFileSync(SERVER_INFO_PATH, "utf-8"));
+}
+
+function apiUrl(baseUrl: string, path: string): URL {
+	return buildFromBase(parseSafeHttpBaseUrl(baseUrl), path);
 }
 
 /**
@@ -43,7 +48,7 @@ async function createInviteViaApi(email: string, role = 30): Promise<string> {
 	const { baseUrl, token, sessionCookie } = getServerInfo();
 
 	// Clear previously captured emails
-	await fetch(`${baseUrl}/_emdash/api/dev/emails`, {
+	await fetch(apiUrl(baseUrl, "/_emdash/api/dev/emails"), {
 		method: "DELETE",
 		headers: {
 			"X-EmDash-Request": "1",
@@ -52,7 +57,7 @@ async function createInviteViaApi(email: string, role = 30): Promise<string> {
 	});
 
 	// Create the invite
-	const createRes = await fetch(`${baseUrl}/_emdash/api/auth/invite`, {
+	const createRes = await fetch(apiUrl(baseUrl, "/_emdash/api/auth/invite"), {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
@@ -77,7 +82,7 @@ async function createInviteViaApi(email: string, role = 30): Promise<string> {
 	}
 
 	// Otherwise, retrieve the invite URL from captured dev emails
-	const emailsRes = await fetch(`${baseUrl}/_emdash/api/dev/emails`, {
+	const emailsRes = await fetch(apiUrl(baseUrl, "/_emdash/api/dev/emails"), {
 		headers: {
 			Authorization: `Bearer ${token}`,
 		},
@@ -173,7 +178,7 @@ test.describe("Invite creation via API", () => {
 	test("creating invite for existing user returns error", async () => {
 		const { baseUrl, token } = getServerInfo();
 
-		const res = await fetch(`${baseUrl}/_emdash/api/auth/invite`, {
+		const res = await fetch(apiUrl(baseUrl, "/_emdash/api/auth/invite"), {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
+++ b/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
@@ -8,6 +8,7 @@
 import { readFileSync } from "node:fs";
 
 import { expect, test } from "../fixtures";
+import { buildFromBase, parseSafeHttpBaseUrl } from "../fixtures/safe-base-url";
 import { refreshServerPatAfterDevBypass } from "../fixtures/refresh-server-pat";
 import { SERVER_INFO_PATH } from "../fixtures/server-info-path";
 import { addVirtualWebAuthnAuthenticator } from "../fixtures/virtual-authenticator";
@@ -19,10 +20,11 @@ function fixtureBaseUrl(): string {
 }
 
 async function resetSetup(): Promise<void> {
-	const base = fixtureBaseUrl();
-	const res = await fetch(`${base}/_emdash/api/setup/dev-reset`, {
+	const base = parseSafeHttpBaseUrl(fixtureBaseUrl());
+	const url = buildFromBase(base, "/_emdash/api/setup/dev-reset");
+	const res = await fetch(url, {
 		method: "POST",
-		headers: { "X-EmDash-Request": "1", Origin: base },
+		headers: { "X-EmDash-Request": "1", Origin: base.origin },
 	});
 	if (!res.ok) throw new Error(`dev-reset failed: ${res.status}`);
 }


### PR DESCRIPTION
## What does this PR do?

Adds a small shared helper for e2e base-URL validation and switches invite/setup helper fetch calls to URL-object construction. This addresses `js/file-access-to-http` taint flow findings in fixture-driven request paths.

Closes #132

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Test/fixture hardening only; no visual changes.
