### PR TITLE
fix: gate typegen writers with strict payload validation

### DIFF
--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -14,6 +14,7 @@ import type { AstroIntegration, AstroIntegrationLogger } from "astro";
 
 import { validateAllowedOrigins, validateOriginShape } from "../../auth/allowed-origins.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
+import { validateGeneratedTypesPayload } from "../../typegen/validate.js";
 import { local } from "../storage/adapters.js";
 import { notoSans } from "./font-provider.js";
 import {
@@ -395,12 +396,9 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 						}
 
 						if (needsWrite) {
-							if (result.types.length > 2_000_000) {
-								logger.warn("Typegen output too large; skipping write");
-								return;
-							}
-							if (!result.types.includes("declare")) {
-								logger.warn("Typegen output missing declarations; skipping write");
+							const validation = validateGeneratedTypesPayload(result.types);
+							if (!validation.ok) {
+								logger.warn(`${validation.reason}; skipping write`);
 								return;
 							}
 							await writeFile(outputPath, result.types, "utf-8");

--- a/packages/core/src/cli/commands/dev.ts
+++ b/packages/core/src/cli/commands/dev.ts
@@ -13,6 +13,7 @@ import consola from "consola";
 
 import { createDatabase } from "../../database/connection.js";
 import { runMigrations } from "../../database/migrations/runner.js";
+import { validateGeneratedTypesPayload } from "../../typegen/validate.js";
 
 interface PackageJson {
 	name?: string;
@@ -122,11 +123,9 @@ export const devCommand = defineCommand({
 					const client = createClientFromArgs({ url: remoteUrl });
 					const schema = await client.schemaExport();
 					const types = await client.schemaTypes();
-					if (!types.includes("declare")) {
-						throw new Error("Schema types payload is invalid");
-					}
-					if (types.length > 2_000_000) {
-						throw new Error("Schema types payload is unexpectedly large");
+					const validation = validateGeneratedTypesPayload(types);
+					if (!validation.ok) {
+						throw new Error(validation.reason);
 					}
 
 					const { writeFile, mkdir } = await import("node:fs/promises");

--- a/packages/core/src/cli/commands/types.ts
+++ b/packages/core/src/cli/commands/types.ts
@@ -11,6 +11,7 @@ import { defineCommand } from "citty";
 import consola from "consola";
 
 import { connectionArgs, createClientFromArgs } from "../client-factory.js";
+import { validateGeneratedTypesPayload } from "../../typegen/validate.js";
 
 function isInside(baseDir: string, targetPath: string): boolean {
 	return targetPath === baseDir || targetPath.startsWith(`${baseDir}${sep}`);
@@ -48,11 +49,9 @@ export const typesCommand = defineCommand({
 
 			// Fetch TypeScript types
 			const types = await client.schemaTypes();
-			if (!types.includes("declare")) {
-				throw new Error("Schema types payload is invalid");
-			}
-			if (types.length > 2_000_000) {
-				throw new Error("Schema types payload is unexpectedly large");
+			const validation = validateGeneratedTypesPayload(types);
+			if (!validation.ok) {
+				throw new Error(validation.reason);
 			}
 
 			// Write types file

--- a/packages/core/src/typegen/validate.ts
+++ b/packages/core/src/typegen/validate.ts
@@ -1,0 +1,18 @@
+const TYPEGEN_MAX_BYTES = 2_000_000;
+const FORBIDDEN_CONTROL_PATTERN = /[\u0000\u0001-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
+
+/**
+ * Guard typegen payloads before writing them to disk.
+ */
+export function validateGeneratedTypesPayload(types: string): { ok: true } | { ok: false; reason: string } {
+	if (types.length > TYPEGEN_MAX_BYTES) {
+		return { ok: false, reason: "Schema types payload is unexpectedly large" };
+	}
+	if (!types.includes("declare")) {
+		return { ok: false, reason: "Schema types payload is invalid" };
+	}
+	if (FORBIDDEN_CONTROL_PATTERN.test(types)) {
+		return { ok: false, reason: "Schema types payload contains control characters" };
+	}
+	return { ok: true };
+}


### PR DESCRIPTION
## What does this PR do?

Adds a shared validator for generated TypeScript payloads and applies it consistently across CLI and Astro integration typegen write paths before writing to disk. This addresses `js/http-to-file-access` taint concerns in generated type writer sinks.

Closes #134

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening in file-write paths.
