### PR TITLE
fix: rely on server validation for signup token

### DIFF
--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -24,7 +24,13 @@ import { LogoLockup } from "./Logo.js";
 // ============================================================================
 
 type SignupStep = "email" | "check-email" | "verify" | "complete" | "error";
-const SIGNUP_TOKEN_PATTERN = /^[A-Za-z0-9_-]{20,200}$/;
+const MAX_SIGNUP_TOKEN_LENGTH = 512;
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+
+function isReasonableSignupToken(token: string): boolean {
+	if (token.length === 0 || token.length > MAX_SIGNUP_TOKEN_LENGTH) return false;
+	return !CONTROL_CHAR_PATTERN.test(token);
+}
 
 // ============================================================================
 // Step Components
@@ -305,7 +311,7 @@ export function SignupPage() {
 		const params = new URLSearchParams(window.location.search);
 		const urlToken = params.get("token");
 
-		if (urlToken && SIGNUP_TOKEN_PATTERN.test(urlToken)) {
+		if (urlToken && isReasonableSignupToken(urlToken)) {
 			setToken(urlToken);
 			void verifyToken(urlToken);
 		} else if (urlToken) {


### PR DESCRIPTION
## What does this PR do?

Removes brittle regex-based client-side signup token gating and relies on server verification as the trust boundary, with a minimal client-side sanity bound (length/control chars) to avoid malformed payload abuse.

Closes #136

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening only.
