### PR TITLE
fix: use single-pass HTML entity decoding

### DIFF
--- a/packages/gutenberg-to-portable-text/src/index.ts
+++ b/packages/gutenberg-to-portable-text/src/index.ts
@@ -28,14 +28,8 @@ const ALT_ATTR_PATTERN = /alt=["']([^"']*)["']/i;
 const LIST_ITEM_PATTERN = /<li[^>]*>([\s\S]*?)<\/li>/gu;
 const CODE_TAG_PATTERN = /<code[^>]*>([\s\S]*?)<\/code>/i;
 const FIGCAPTION_TAG_PATTERN = /<figcaption[^>]*>([\s\S]*?)<\/figcaption>/i;
-const AMP_ENTITY_PATTERN = /&amp;/g;
-const LESS_THAN_ENTITY_PATTERN = /&lt;/g;
-const GREATER_THAN_ENTITY_PATTERN = /&gt;/g;
-const QUOTE_ENTITY_PATTERN = /&quot;/g;
-const APOS_ENTITY_PATTERN = /&#039;/g;
-const NUMERIC_AMP_ENTITY_PATTERN = /&#0?38;/g;
-const HEX_AMP_ENTITY_PATTERN = /&#x26;/gi;
-const NBSP_ENTITY_PATTERN = /&nbsp;/g;
+const HTML_ENTITY_PATTERN = /&(lt|gt|amp|quot|#039|nbsp);/g;
+const URL_ENTITY_PATTERN = /&(amp|#0?38|#x26);/gi;
 
 // Re-export types
 export type {
@@ -433,25 +427,31 @@ function transformBlock(
  * Decode HTML entities
  */
 function decodeHtmlEntities(html: string): string {
-	return html
-		.replace(LESS_THAN_ENTITY_PATTERN, "<")
-		.replace(GREATER_THAN_ENTITY_PATTERN, ">")
-		.replace(AMP_ENTITY_PATTERN, "&")
-		.replace(QUOTE_ENTITY_PATTERN, '"')
-		.replace(APOS_ENTITY_PATTERN, "'")
-		.replace(NUMERIC_AMP_ENTITY_PATTERN, "&") // &#038; or &#38;
-		.replace(HEX_AMP_ENTITY_PATTERN, "&") // &#x26;
-		.replace(NBSP_ENTITY_PATTERN, " ");
+	return html.replace(HTML_ENTITY_PATTERN, (entity) => {
+		switch (entity) {
+			case "&lt;":
+				return "<";
+			case "&gt;":
+				return ">";
+			case "&amp;":
+				return "&";
+			case "&quot;":
+				return '"';
+			case "&#039;":
+				return "'";
+			case "&nbsp;":
+				return " ";
+			default:
+				return entity;
+		}
+	});
 }
 
 /**
  * Decode HTML entities in URLs (used for image src attributes)
  */
 function decodeUrlEntities(url: string): string {
-	return url
-		.replace(AMP_ENTITY_PATTERN, "&")
-		.replace(NUMERIC_AMP_ENTITY_PATTERN, "&")
-		.replace(HEX_AMP_ENTITY_PATTERN, "&");
+	return url.replace(URL_ENTITY_PATTERN, "&");
 }
 
 /**

--- a/packages/gutenberg-to-portable-text/src/inline.ts
+++ b/packages/gutenberg-to-portable-text/src/inline.ts
@@ -31,9 +31,7 @@ const BLOCK_TAG_PATTERNS: Record<string, { open: RegExp; close: RegExp }> = {
 const IMG_ALT_PATTERN = /<img[^>]+alt=["']([^"']*)["']/i;
 const FIGCAPTION_PATTERN = /<figcaption[^>]*>([\s\S]*?)<\/figcaption>/i;
 const IMG_SRC_PATTERN = /<img[^>]+src=["']([^"']*)["']/i;
-const URL_AMP_ENTITY_PATTERN = /&amp;/g;
-const URL_NUMERIC_AMP_ENTITY_PATTERN = /&#0?38;/g;
-const URL_HEX_AMP_ENTITY_PATTERN = /&#x26;/gi;
+const URL_ENTITY_PATTERN = /&(amp|#0?38|#x26);/gi;
 
 type Node = DefaultTreeAdapterMap["node"];
 type TextNode = DefaultTreeAdapterMap["textNode"];
@@ -326,8 +324,5 @@ export function extractSrc(html: string): string | undefined {
  * Decode HTML entities commonly found in URLs
  */
 function decodeUrlEntities(url: string): string {
-	return url
-		.replace(URL_AMP_ENTITY_PATTERN, "&")
-		.replace(URL_NUMERIC_AMP_ENTITY_PATTERN, "&")
-		.replace(URL_HEX_AMP_ENTITY_PATTERN, "&");
+	return url.replace(URL_ENTITY_PATTERN, "&");
 }

--- a/packages/gutenberg-to-portable-text/src/transformers/core.ts
+++ b/packages/gutenberg-to-portable-text/src/transformers/core.ts
@@ -31,12 +31,7 @@ const TABLE_ROW_PATTERN = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
 const TABLE_CELL_PATTERN = /<(th|td)[^>]*>([\s\S]*?)<\/\1>/gi;
 const TBODY_TAG_PATTERN = /<tbody[^>]*>([\s\S]*?)<\/tbody>/i;
 const CITE_TAG_PATTERN = /<cite[^>]*>([\s\S]*?)<\/cite>/i;
-const LT_ENTITY_PATTERN = /&lt;/g;
-const GT_ENTITY_PATTERN = /&gt;/g;
-const AMP_ENTITY_PATTERN = /&amp;/g;
-const QUOT_ENTITY_PATTERN = /&quot;/g;
-const APOS_ENTITY_PATTERN = /&#039;/g;
-const NBSP_ENTITY_PATTERN = /&nbsp;/g;
+const HTML_ENTITY_PATTERN = /&(lt|gt|amp|quot|#039|nbsp);/g;
 
 /**
  * core/paragraph → block with style "normal"
@@ -720,13 +715,24 @@ function mapAlignment(
  * Decode HTML entities
  */
 function decodeHtmlEntities(html: string): string {
-	return html
-		.replace(LT_ENTITY_PATTERN, "<")
-		.replace(GT_ENTITY_PATTERN, ">")
-		.replace(AMP_ENTITY_PATTERN, "&")
-		.replace(QUOT_ENTITY_PATTERN, '"')
-		.replace(APOS_ENTITY_PATTERN, "'")
-		.replace(NBSP_ENTITY_PATTERN, " ");
+	return html.replace(HTML_ENTITY_PATTERN, (entity) => {
+		switch (entity) {
+			case "&lt;":
+				return "<";
+			case "&gt;":
+				return ">";
+			case "&amp;":
+				return "&";
+			case "&quot;":
+				return '"';
+			case "&#039;":
+				return "'";
+			case "&nbsp;":
+				return " ";
+			default:
+				return entity;
+		}
+	});
 }
 
 /**

--- a/packages/gutenberg-to-portable-text/tests/converter.test.ts
+++ b/packages/gutenberg-to-portable-text/tests/converter.test.ts
@@ -1261,6 +1261,14 @@ describe("WordPress.com classic editor content", () => {
 		expect(img.asset.url).toBe("https://example.com/photo.jpg?a=1&b=2");
 	});
 
+	it("decodes URL entities in a single pass", () => {
+		const html = `<p><img src="https://example.com/photo.jpg?a=1&amp;#38;b=2" alt="test"></p>`;
+		const result = htmlToPortableText(html);
+
+		const img = result.find((b) => b._type === "image") as PortableTextImageBlock;
+		expect(img.asset.url).toBe("https://example.com/photo.jpg?a=1&#38;b=2");
+	});
+
 	// Test for figure with HTML entities
 	it("decodes HTML entities in figure images", () => {
 		const html = `<figure><img src="https://example.com/photo.jpg?w=200&#038;h=300" alt="test"><figcaption>Caption</figcaption></figure>`;


### PR DESCRIPTION
## What does this PR do?

Replaces chained HTML entity decode replacements with single-pass entity decoding in Gutenberg conversion helpers, reducing double-escaping/double-decoding risk flagged by CodeQL.

Closes #138

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Added regression asserting nested entity encoding decodes once, not twice.
