### PR TITLE
fix: validate schema payloads before schema.json writes

### DIFF
--- a/packages/core/src/cli/commands/dev.ts
+++ b/packages/core/src/cli/commands/dev.ts
@@ -13,7 +13,10 @@ import consola from "consola";
 
 import { createDatabase } from "../../database/connection.js";
 import { runMigrations } from "../../database/migrations/runner.js";
-import { validateGeneratedTypesPayload } from "../../typegen/validate.js";
+import {
+	validateGeneratedTypesPayload,
+	validateSchemaExportPayload,
+} from "../../typegen/validate.js";
 
 interface PackageJson {
 	name?: string;
@@ -122,6 +125,10 @@ export const devCommand = defineCommand({
 					const { createClientFromArgs } = await import("../client-factory.js");
 					const client = createClientFromArgs({ url: remoteUrl });
 					const schema = await client.schemaExport();
+					const schemaValidation = validateSchemaExportPayload(schema);
+					if (!schemaValidation.ok) {
+						throw new Error(schemaValidation.reason);
+					}
 					const types = await client.schemaTypes();
 					const validation = validateGeneratedTypesPayload(types);
 					if (!validation.ok) {
@@ -138,7 +145,7 @@ export const devCommand = defineCommand({
 					await writeFile(outputPath, types, "utf-8");
 					await writeFile(
 						resolvePath(dirname(outputPath), "schema.json"),
-						JSON.stringify(schema, null, 2),
+						schemaValidation.serialized,
 						"utf-8",
 					);
 					consola.success(`Generated types for ${schema.collections.length} collections`);

--- a/packages/core/src/cli/commands/types.ts
+++ b/packages/core/src/cli/commands/types.ts
@@ -11,7 +11,10 @@ import { defineCommand } from "citty";
 import consola from "consola";
 
 import { connectionArgs, createClientFromArgs } from "../client-factory.js";
-import { validateGeneratedTypesPayload } from "../../typegen/validate.js";
+import {
+	validateGeneratedTypesPayload,
+	validateSchemaExportPayload,
+} from "../../typegen/validate.js";
 
 function isInside(baseDir: string, targetPath: string): boolean {
 	return targetPath === baseDir || targetPath.startsWith(`${baseDir}${sep}`);
@@ -45,6 +48,10 @@ export const typesCommand = defineCommand({
 
 			// Fetch JSON schema
 			const schema = await client.schemaExport();
+			const schemaValidation = validateSchemaExportPayload(schema);
+			if (!schemaValidation.ok) {
+				throw new Error(schemaValidation.reason);
+			}
 			consola.success(`Found ${schema.collections.length} collections`);
 
 			// Fetch TypeScript types
@@ -65,7 +72,7 @@ export const typesCommand = defineCommand({
 
 			// Also write a schema.json for reference
 			const schemaJsonPath = resolve(dirname(outputPath), "schema.json");
-			await writeFile(schemaJsonPath, JSON.stringify(schema, null, 2), "utf-8");
+			await writeFile(schemaJsonPath, schemaValidation.serialized, "utf-8");
 			consola.info(`Schema version: ${schema.version}`);
 
 			consola.box({

--- a/packages/core/src/typegen/validate.ts
+++ b/packages/core/src/typegen/validate.ts
@@ -1,5 +1,6 @@
 const TYPEGEN_MAX_BYTES = 2_000_000;
 const FORBIDDEN_CONTROL_PATTERN = /[\u0000\u0001-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
+const SCHEMA_JSON_MAX_BYTES = 2_000_000;
 
 /**
  * Guard typegen payloads before writing them to disk.
@@ -15,4 +16,30 @@ export function validateGeneratedTypesPayload(types: string): { ok: true } | { o
 		return { ok: false, reason: "Schema types payload contains control characters" };
 	}
 	return { ok: true };
+}
+
+/**
+ * Guard schema export payloads before writing them to disk.
+ */
+export function validateSchemaExportPayload(
+	schema: unknown,
+): { ok: true; serialized: string } | { ok: false; reason: string } {
+	if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+		return { ok: false, reason: "Schema export payload is invalid" };
+	}
+
+	const record = schema as Record<string, unknown>;
+	if (!Array.isArray(record.collections)) {
+		return { ok: false, reason: "Schema export payload is invalid" };
+	}
+	if (typeof record.version !== "number") {
+		return { ok: false, reason: "Schema export payload is invalid" };
+	}
+
+	const serialized = JSON.stringify(schema, null, 2);
+	if (serialized.length > SCHEMA_JSON_MAX_BYTES) {
+		return { ok: false, reason: "Schema export payload is unexpectedly large" };
+	}
+
+	return { ok: true, serialized };
 }


### PR DESCRIPTION
## What does this PR do?

Adds shared schema payload validation for CLI typegen write paths so remote schema data is shape-checked and size-bounded before writing `schema.json` to disk.

Closes #140

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening for file-write paths.
