### PR TITLE
fix: add upload size cap to local storage

### DIFF
--- a/packages/core/src/storage/local.ts
+++ b/packages/core/src/storage/local.ts
@@ -34,6 +34,7 @@ const LEADING_SLASH_PATTERN = /^\//;
 /** Pattern to remove trailing slashes */
 const TRAILING_SLASH_PATTERN = /\/$/;
 const SAFE_KEY_PATTERN = /^[A-Za-z0-9._/-]+$/;
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // 100 MB
 
 /**
  * Local filesystem storage implementation
@@ -97,6 +98,13 @@ export class LocalStorage implements Storage {
 				buffer = Buffer.from(options.body);
 			} else {
 				buffer = options.body;
+			}
+
+			if (buffer.length > MAX_UPLOAD_BYTES) {
+				throw new EmDashStorageError(
+					`Upload exceeds maximum size: ${options.key}`,
+					"UPLOAD_FAILED",
+				);
 			}
 
 			await fs.writeFile(filePath, buffer);


### PR DESCRIPTION
## What does this PR do?

Hardens the local storage upload handler against unbounded file writes by adding a maximum upload buffer size check before `writeFile`.

Closes #144

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Non-visual security hardening only.
