### PR TITLE
fix: add input size guard to gutenberg converter

### DIFF
--- a/packages/gutenberg-to-portable-text/src/index.ts
+++ b/packages/gutenberg-to-portable-text/src/index.ts
@@ -17,6 +17,9 @@ import type {
 	TransformContext,
 } from "./types.js";
 
+/** Maximum input length to prevent polynomial regex backtracking on pathological HTML */
+export const MAX_CONVERTER_INPUT_LENGTH = 10_000_000; // 10 MB
+
 // Regex patterns for HTML parsing and conversion
 const BLOCK_ELEMENT_PATTERN =
 	/<(p|h[1-6]|blockquote|pre|ul|ol|figure|div|hr)[^>]*>([\s\S]*?)<\/\1>|<(hr|br)\s*\/?>|<img\s+[^>]+\/?>/gu;
@@ -118,6 +121,11 @@ export function gutenbergToPortableText(
 	content: string,
 	options: ConvertOptions = {},
 ): PortableTextBlock[] {
+	// Reject pathologically large inputs to prevent polynomial regex backtracking
+	if (content.length > MAX_CONVERTER_INPUT_LENGTH) {
+		return [];
+	}
+
 	// Handle empty content
 	if (!content || !content.trim()) {
 		return [];
@@ -151,6 +159,11 @@ export function htmlToPortableText(
 	html: string,
 	options: ConvertOptions = {},
 ): PortableTextBlock[] {
+	// Reject pathologically large inputs to prevent polynomial regex backtracking
+	if (html.length > MAX_CONVERTER_INPUT_LENGTH) {
+		return [];
+	}
+
 	const generateKey = options.keyGenerator || createKeyGenerator();
 	const blocks: PortableTextBlock[] = [];
 


### PR DESCRIPTION
## What does this PR do?

Adds a `MAX_CONVERTER_INPUT_LENGTH` guard to `gutenbergToPortableText` and `htmlToPortableText` entry points to mitigate polynomial regex backtracking on pathologically large inputs.

Closes #146

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)

## Screenshots / test output

- Both entry points (`gutenbergToPortableText`, `htmlToPortableText`) now bail early on inputs exceeding 10 MB.
