### PR TITLE
fix: use explicit type assertion on JSON.stringify fallback

### DIFF
--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -940,8 +940,7 @@ export class SchemaRegistry {
 				text = String(value);
 				break;
 			case "object": {
-				const raw = value === null ? undefined : JSON.stringify(value);
-				text = raw !== undefined ? raw : "";
+				text = value === null ? "" : (JSON.stringify(value) as string | undefined) ?? "";
 				break;
 			}
 			default:


### PR DESCRIPTION
## What does this PR do?

Final adjustment to the `JSON.stringify` fallback path in the schema registry to make the type narrowing explicit with `as string | undefined`.

Closes #148

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm format` has been run
- [x] User-visible strings in admin UI are wrapped for translation (if applicable)
- [ ] Changeset added (if needed)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.3 Codex (OpenCode CLI)
